### PR TITLE
softlayer: add discover code for SoftLayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ provider=gce project_name=... zone_pattern=eu-west-* tag_value=consul credential
 
 # Microsoft Azure
 provider=azure tag_name=consul tag_value=... tenant_id=... client_id=... subscription_id=... secret_access_key=...
+
+# SoftLayer
+provider=softlayer datacenter=dal06 tag_value=consul username=... api_key=...
 ```
 
 ### Supported Providers
@@ -31,6 +34,7 @@ can be added to the `discover.Disoverers` map.
  * Amazon AWS [Config options](http://godoc.org/github.com/hashicorp/go-discover/aws)
  * Google Cloud [Config options](http://godoc.org/github.com/hashicorp/go-discover/gce)
  * Microsoft Azure [Config options](http://godoc.org/github.com/hashicorp/go-discover/azure)
+ * SoftLayer [Config options](http://godoc.org/github.com/hashicorp/go-discover/softlayer)
 
 ## Command Line Tool Usage
 
@@ -67,4 +71,3 @@ addrs, err := discover.Discover(args, l)
 
 For complete API documentation, see [GoDoc](https://godoc.org/github.com/hashicorp/go-discover) and
 the [supported providers](http://godoc.org/github.com/hashicorp/go-discover#pkg-subdirectories).
-

--- a/discover.go
+++ b/discover.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-discover/azure"
 	"github.com/hashicorp/go-discover/config"
 	"github.com/hashicorp/go-discover/gce"
+	"github.com/hashicorp/go-discover/softlayer"
 )
 
 // Discoverer is the signature of the function to discover ip addresses of nodes
@@ -23,6 +24,7 @@ func init() {
 		"aws":   aws.Discover,
 		"gce":   gce.Discover,
 		"azure": azure.Discover,
+		"softlayer": softlayer.Discover,
 	}
 }
 

--- a/softlayer/softlayer_discover.go
+++ b/softlayer/softlayer_discover.go
@@ -1,0 +1,68 @@
+// Package softlayer provides node discovery for Softlayer.
+package softlayer
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-discover/config"
+	"github.com/softlayer/softlayer-go/filter"
+	"github.com/softlayer/softlayer-go/services"
+	"github.com/softlayer/softlayer-go/session"
+)
+
+// Discover returns the private ip addresses of all Softlayer
+// instances in a datacenter with a certain tag value.
+//
+// cfg contains the configuration in "key=val key=val ..." format. The
+// values are URL encoded.
+//
+// The supported keys are:
+//
+//   datacenter: The SoftLayer datacenter to filter on
+//   tag_value:  The tag value to filter on
+//   username:   The SoftLayer username to use
+//   api_key:    The SoftLayer api key to use
+//
+// Example:
+//
+//  provider=softlayer datacenter=dal06 tag_value=consul username=... api_key=...
+//
+func Discover(cfg string, l *log.Logger) ([]string, error) {
+	m, err := config.Parse(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("discover-softlayer: %s", err)
+	}
+
+	datacenter := m["datacenter"]
+	tagValue := m["tag_value"]
+	username := m["username"]
+	apiKey := m["api_key"]
+
+	l.Printf("[INFO] discover-softlayer: Datacenter is %q", datacenter)
+
+	// Create a session and get a service
+	sess := session.New(username, apiKey)
+	service := services.GetAccountService(sess)
+
+	// Compose the filter
+	mask := "id,hostname,domain,tagReferences[tag[name]],primaryBackendIpAddress,datacenter"
+	filterVMs := filter.Build(
+		filter.Path("virtualGuests.datacenter.name").Eq(datacenter),
+		filter.Path("virtualGuests.tagReferences.tag.name").Eq(tagValue),
+	)
+
+	// Get the virtual machines that match the filter
+	vms, err := service.Mask(mask).Filter(filterVMs).GetVirtualGuests()
+	if err != nil {
+		return nil, fmt.Errorf("discover-softlayer: %s", err)
+	}
+
+	var addrs []string
+	for _, vm := range vms {
+		l.Printf("[INFO] discover-softlayer: Found instance (%d) %s.%s with private IP: %s",
+			*vm.Id, *vm.Hostname, *vm.Domain, *vm.PrimaryBackendIpAddress)
+		addrs = append(addrs, *vm.PrimaryBackendIpAddress)
+	}
+	return addrs, nil
+}

--- a/softlayer/softlayer_discover_test.go
+++ b/softlayer/softlayer_discover_test.go
@@ -1,0 +1,31 @@
+package softlayer
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestDiscover(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("SL_USERNAME") == "" {
+		t.Skip("SL_USERNAME not set, skipping")
+	}
+
+	if os.Getenv("SL_API_KEY") == "" {
+		t.Skip("SL_API_KEY not set, skipping")
+	}
+
+	cfg := fmt.Sprintf("username=%s api_key=%s datacenter=%s tag_value=%s",
+		os.Getenv("SL_USERNAME"), os.Getenv("SL_API_KEY"), "dal06", "consul-server")
+
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	addrs, err := Discover(cfg, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 3 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}


### PR DESCRIPTION
This PR adds host discovery for SoftLayer. Initially opened for Consul in https://github.com/hashicorp/consul/pull/2879

---

Verified it as working this snippet:

```
package main

import (
	"log"
	"os"

	"github.com/hashicorp/go-discover"
)

func main() {
	l := log.New(os.Stderr, "", log.LstdFlags)
	args := "provider=softlayer datacenter=dal06 tag_value=consul:consul-server username=<username> api_key=<api-key>"
	addrs, err := discover.Discover(args, l)
	if err != nil {
		log.Println("Mmmm...")
	}
	log.Printf("%v\n", addrs)
}

```

Output:

```
2017/07/05 22:16:20 [INFO] discover-softlayer: Datacenter is "dal06"
2017/07/05 22:16:21 [INFO] discover-softlayer: Found instance (XXXXXXX1) <hostname1>.<domain> with private IP: 10.X.Y.1
2017/07/05 22:16:21 [INFO] discover-softlayer: Found instance (XXXXXXX2) <hostname2>.<domain> with private IP: 10.X.Y.2
2017/07/05 22:16:21 [INFO] discover-softlayer: Found instance (XXXXXXX3) <hostname3>.<domain> with private IP: 10.X.Y.3
2017/07/05 22:16:21 [10.X.Y.1 10.X.Y.2 10.X.Y.3]
```