### PR TITLE
digitalocean: add discover code for DigitalOcean

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ sub packages. Additional providers can be added through the [Register](https://g
 function.
 
  * Amazon AWS [Config options](http://godoc.org/github.com/hashicorp/go-discover/provider/aws)
+ * DigitalOcean [Config options](http://godoc.org/github.com/hashicorp/go-discover/provider/digitalocean)
  * Google Cloud [Config options](http://godoc.org/github.com/hashicorp/go-discover/provider/gce)
  * Microsoft Azure [Config options](http://godoc.org/github.com/hashicorp/go-discover/provider/azure)
  * SoftLayer [Config options](http://godoc.org/github.com/hashicorp/go-discover/provider/softlayer)
@@ -27,6 +28,9 @@ function.
 ```
 # Amazon AWS
 provider=aws region=eu-west-1 tag_key=consul tag_value=... access_key_id=... secret_access_key=...
+
+# DigitalOcean
+provider=digitalocean region=nyc3 tag_value=... api_key=...
 
 # Google Cloud
 provider=gce project_name=... zone_pattern=eu-west-* tag_value=consul credentials_file=...

--- a/discover.go
+++ b/discover.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-discover/provider/aws"
 	"github.com/hashicorp/go-discover/provider/azure"
+	"github.com/hashicorp/go-discover/provider/digitalocean"
 	"github.com/hashicorp/go-discover/provider/gce"
 	"github.com/hashicorp/go-discover/provider/softlayer"
 )
@@ -28,10 +29,11 @@ type Provider interface {
 
 // Providers contains all available providers.
 var Providers = map[string]Provider{
-	"aws":       &aws.Provider{},
-	"azure":     &azure.Provider{},
-	"gce":       &gce.Provider{},
-	"softlayer": &softlayer.Provider{},
+	"aws":          &aws.Provider{},
+	"azure":        &azure.Provider{},
+	"digitalocean": &digitalocean.Provider{},
+	"gce":          &gce.Provider{},
+	"softlayer":    &softlayer.Provider{},
 }
 
 // Discover looks up metadata in different cloud environments.

--- a/provider/digitalocean/digitalocean_discover.go
+++ b/provider/digitalocean/digitalocean_discover.go
@@ -1,0 +1,118 @@
+// Package digitalocean provides node discovery for DigitalOcean.
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	"golang.org/x/oauth2"
+
+	"github.com/digitalocean/godo"
+)
+
+type Provider struct{}
+
+func (p *Provider) Help() string {
+	return `DigitalOcean:
+
+    provider:   "digitalocean"
+    region:     The DigitalOcean region to filter on
+    tag_value:  The tag value to filter on
+    addr_type:  "private_v4", "public_v4" or "public_v6". Defaults to "public_v4".
+    api_key:    The DigitalOcean api key to use
+`
+}
+
+func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error) {
+	if args["provider"] != "digitalocean" {
+		return nil, fmt.Errorf("discover-digitalocean: invalid provider " + args["provider"])
+	}
+
+	if l == nil {
+		l = log.New(ioutil.Discard, "", 0)
+	}
+
+	region := args["region"]
+	tagValue := args["tag_value"]
+	apiKey := args["api_key"]
+	addrType := args["addr_type"]
+
+	l.Printf("[INFO] discover-digitalocean: Region is %q", region)
+
+	if addrType != "private_v4" && addrType != "public_v4" && addrType != "public_v6" {
+		l.Printf("[INFO] discover-digitalocean: Address type %s is not supported. Valid values are {private_v4,public_v4,public_v6}. Falling back to 'public_v4'", addrType)
+		addrType = "public_v4"
+	}
+
+	if addrType == "" {
+		l.Printf("[DEBUG] discover-digitalocean: Address type not provided. Using 'public_v4'")
+		addrType = "public_v4"
+	}
+
+	client := newClientFromToken(apiKey)
+
+	// Get the droplets for that tag
+	droplets, _, err := client.Droplets.ListByTag(context.Background(), tagValue, nil)
+	if err != nil {
+		return nil, fmt.Errorf("discover-digitalocean: %s", err)
+	}
+
+	var addrs []string
+	for _, droplet := range droplets {
+		// Ignore droplets not in the requested region
+		if droplet.Region.Slug != region {
+			continue
+		}
+
+		var (
+			addr string
+			err error
+		)
+		switch addrType {
+		case "public_v4":
+			addr, err = droplet.PublicIPv4()
+			if err != nil {
+				fmt.Errorf("discover-digitalocean: %s", err)
+				continue
+			}
+		case "private_v4":
+			addr, err = droplet.PrivateIPv4()
+			if err != nil {
+				fmt.Errorf("discover-digitalocean: %s", err)
+				continue
+			}
+		case "public_v6":
+			addr, err = droplet.PublicIPv6()
+			if err != nil {
+				fmt.Errorf("discover-digitalocean: %s", err)
+				continue
+			}
+		}
+
+		l.Printf("[INFO] discover-digitalocean: Found instance (%d) %s with IP: %s",
+			droplet.ID, droplet.Name, addr)
+		addrs = append(addrs, addr)
+	}
+	return addrs, nil
+}
+
+type TokenSource struct {
+	AccessToken string
+}
+
+func (t *TokenSource) Token() (*oauth2.Token, error) {
+	token := &oauth2.Token{
+		AccessToken: t.AccessToken,
+	}
+	return token, nil
+}
+
+func newClientFromToken(pat string) *godo.Client {
+	tokenSource := &TokenSource{
+		AccessToken: pat,
+	}
+	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
+	return godo.NewClient(oauthClient)
+}

--- a/provider/digitalocean/digitalocean_discover_test.go
+++ b/provider/digitalocean/digitalocean_discover_test.go
@@ -1,0 +1,33 @@
+package digitalocean_test
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/go-discover/provider/digitalocean"
+	discover "github.com/hashicorp/go-discover"
+)
+
+func TestAddrs(t *testing.T) {
+	args := discover.Config{
+		"provider":  "digitalocean",
+		"api_key":   os.Getenv("DIGITALOCEAN_API_KEY"),
+		"region":    "nyc3",
+		"tag_value": "consul-server",
+		"addr_type": "public_v4",
+	}
+	if args["api_key"] == "" {
+		t.Skip("DigitalOcean credentials missing")
+	}
+
+	p := &digitalocean.Provider{}
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	addrs, err := p.Addrs(args, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 3 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+
+## [v1.1.0] - 2017-06-06
+
+### Added
+- #145 Add FirewallsService for managing Firewalls with the DigitalOcean API. - @viola
+- #139 Add TTL field to the Domains. - @xmudrii
+
+### Fixed
+- #143 Fix oauth2.NoContext depreciation. - @jbowens
+- #141 Fix DropletActions on tagged resources. - @xmudrii
+
+## [v1.0.0] - 2017-03-10
+
+### Added
+- #130 Add Convert to ImageActionsService. - @xmudrii
+- #126 Add CertificatesService for managing certificates with the DigitalOcean API. - @viola
+- #125 Add LoadBalancersService for managing load balancers with the DigitalOcean API. - @viola
+- #122 Add GetVolumeByName to StorageService. - @protochron
+- #113 Add context.Context to all calls. - @aybabtme

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/CONTRIBUTING.md
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+If you submit a pull request, please keep the following guidelines in mind:
+
+1. Code should be `go fmt` compliant.
+2. Types, structs and funcs should be documented.
+3. Tests pass.
+
+## Getting set up
+
+Assuming your `$GOPATH` is set up according to your desires, run:
+
+```sh
+go get github.com/digitalocean/godo
+```
+
+## Running tests
+
+When working on code in this repository, tests can be run via:
+
+```sh
+go test .
+```

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/LICENSE.txt
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/LICENSE.txt
@@ -1,0 +1,55 @@
+Copyright (c) 2014-2016 The godo AUTHORS. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+======================
+Portions of the client are based on code at:
+https://github.com/google/go-github/
+
+Copyright (c) 2013 The go-github AUTHORS. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/README.md
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/README.md
@@ -1,0 +1,138 @@
+[![Build Status](https://travis-ci.org/digitalocean/godo.svg)](https://travis-ci.org/digitalocean/godo)
+
+# Godo
+
+Godo is a Go client library for accessing the DigitalOcean V2 API.
+
+You can view the client API docs here: [http://godoc.org/github.com/digitalocean/godo](http://godoc.org/github.com/digitalocean/godo)
+
+You can view DigitalOcean API docs here: [https://developers.digitalocean.com/documentation/v2/](https://developers.digitalocean.com/documentation/v2/)
+
+
+## Usage
+
+```go
+import "github.com/digitalocean/godo"
+```
+
+Create a new DigitalOcean client, then use the exposed services to
+access different parts of the DigitalOcean API.
+
+### Authentication
+
+Currently, Personal Access Token (PAT) is the only method of
+authenticating with the API. You can manage your tokens
+at the DigitalOcean Control Panel [Applications Page](https://cloud.digitalocean.com/settings/applications).
+
+You can then use your token to create a new client:
+
+```go
+import "golang.org/x/oauth2"
+
+pat := "mytoken"
+type TokenSource struct {
+    AccessToken string
+}
+
+func (t *TokenSource) Token() (*oauth2.Token, error) {
+    token := &oauth2.Token{
+        AccessToken: t.AccessToken,
+    }
+    return token, nil
+}
+
+tokenSource := &TokenSource{
+    AccessToken: pat,
+}
+oauthClient := oauth2.NewClient(context.Background(), tokenSource)
+client := godo.NewClient(oauthClient)
+```
+
+## Examples
+
+
+To create a new Droplet:
+
+```go
+dropletName := "super-cool-droplet"
+
+createRequest := &godo.DropletCreateRequest{
+    Name:   dropletName,
+    Region: "nyc3",
+    Size:   "512mb",
+    Image: godo.DropletCreateImage{
+        Slug: "ubuntu-14-04-x64",
+    },
+}
+
+ctx := context.TODO()
+
+newDroplet, _, err := client.Droplets.Create(ctx, createRequest)
+
+if err != nil {
+    fmt.Printf("Something bad happened: %s\n\n", err)
+    return err
+}
+```
+
+### Pagination
+
+If a list of items is paginated by the API, you must request pages individually. For example, to fetch all Droplets:
+
+```go
+func DropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, error) {
+    // create a list to hold our droplets
+    list := []godo.Droplet{}
+
+    // create options. initially, these will be blank
+    opt := &godo.ListOptions{}
+    for {
+        droplets, resp, err := client.Droplets.List(ctx, opt)
+        if err != nil {
+            return nil, err
+        }
+
+        // append the current page's droplets to our list
+        for _, d := range droplets {
+            list = append(list, d)
+        }
+
+        // if we are at the last page, break out the for loop
+        if resp.Links == nil || resp.Links.IsLastPage() {
+            break
+        }
+
+        page, err := resp.Links.CurrentPage()
+        if err != nil {
+            return nil, err
+        }
+
+        // set the page we want for the next request
+        opt.Page = page + 1
+    }
+
+    return list, nil
+}
+```
+
+## Versioning
+
+Each version of the client is tagged and the version is updated accordingly.
+
+Since Go does not have a built-in versioning, a package management tool is
+recommended - a good one that works with git tags is
+[gopkg.in](http://labix.org/gopkg.in).
+
+To see the list of past versions, run `git tag`.
+
+
+## Documentation
+
+For a comprehensive list of examples, check out the [API documentation](https://developers.digitalocean.com/documentation/v2/).
+
+For details on all the functionality in this library, see the [GoDoc](http://godoc.org/github.com/digitalocean/godo) documentation.
+
+
+## Contributing
+
+We love pull requests! Please see the [contribution guidelines](CONTRIBUTING.md).

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/account.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/account.go
@@ -1,0 +1,60 @@
+package godo
+
+import (
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+// AccountService is an interface for interfacing with the Account
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2/#account
+type AccountService interface {
+	Get(context.Context) (*Account, *Response, error)
+}
+
+// AccountServiceOp handles communication with the Account related methods of
+// the DigitalOcean API.
+type AccountServiceOp struct {
+	client *Client
+}
+
+var _ AccountService = &AccountServiceOp{}
+
+// Account represents a DigitalOcean Account
+type Account struct {
+	DropletLimit    int    `json:"droplet_limit,omitempty"`
+	FloatingIPLimit int    `json:"floating_ip_limit,omitempty"`
+	Email           string `json:"email,omitempty"`
+	UUID            string `json:"uuid,omitempty"`
+	EmailVerified   bool   `json:"email_verified,omitempty"`
+	Status          string `json:"status,omitempty"`
+	StatusMessage   string `json:"status_message,omitempty"`
+}
+
+type accountRoot struct {
+	Account *Account `json:"account"`
+}
+
+func (r Account) String() string {
+	return Stringify(r)
+}
+
+// Get DigitalOcean account info
+func (s *AccountServiceOp) Get(ctx context.Context) (*Account, *Response, error) {
+
+	path := "v2/account"
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(accountRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Account, resp, err
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/action.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/action.go
@@ -1,0 +1,105 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const (
+	actionsBasePath = "v2/actions"
+
+	// ActionInProgress is an in progress action status
+	ActionInProgress = "in-progress"
+
+	//ActionCompleted is a completed action status
+	ActionCompleted = "completed"
+)
+
+// ActionsService handles communction with action related methods of the
+// DigitalOcean API: https://developers.digitalocean.com/documentation/v2#actions
+type ActionsService interface {
+	List(context.Context, *ListOptions) ([]Action, *Response, error)
+	Get(context.Context, int) (*Action, *Response, error)
+}
+
+// ActionsServiceOp handles communition with the image action related methods of the
+// DigitalOcean API.
+type ActionsServiceOp struct {
+	client *Client
+}
+
+var _ ActionsService = &ActionsServiceOp{}
+
+type actionsRoot struct {
+	Actions []Action `json:"actions"`
+	Links   *Links   `json:"links"`
+}
+
+type actionRoot struct {
+	Event *Action `json:"action"`
+}
+
+// Action represents a DigitalOcean Action
+type Action struct {
+	ID           int        `json:"id"`
+	Status       string     `json:"status"`
+	Type         string     `json:"type"`
+	StartedAt    *Timestamp `json:"started_at"`
+	CompletedAt  *Timestamp `json:"completed_at"`
+	ResourceID   int        `json:"resource_id"`
+	ResourceType string     `json:"resource_type"`
+	Region       *Region    `json:"region,omitempty"`
+	RegionSlug   string     `json:"region_slug,omitempty"`
+}
+
+// List all actions
+func (s *ActionsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Action, *Response, error) {
+	path := actionsBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Actions, resp, err
+}
+
+// Get an action by ID.
+func (s *ActionsServiceOp) Get(ctx context.Context, id int) (*Action, *Response, error) {
+	if id < 1 {
+		return nil, nil, NewArgError("id", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d", actionsBasePath, id)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+func (a Action) String() string {
+	return Stringify(a)
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/certificates.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/certificates.go
@@ -1,0 +1,122 @@
+package godo
+
+import (
+	"net/http"
+	"path"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const certificatesBasePath = "/v2/certificates"
+
+// CertificatesService is an interface for managing certificates with the DigitalOcean API.
+// See: https://developers.digitalocean.com/documentation/v2/#certificates
+type CertificatesService interface {
+	Get(context.Context, string) (*Certificate, *Response, error)
+	List(context.Context, *ListOptions) ([]Certificate, *Response, error)
+	Create(context.Context, *CertificateRequest) (*Certificate, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+}
+
+// Certificate represents a DigitalOcean certificate configuration.
+type Certificate struct {
+	ID              string `json:"id,omitempty"`
+	Name            string `json:"name,omitempty"`
+	NotAfter        string `json:"not_after,omitempty"`
+	SHA1Fingerprint string `json:"sha1_fingerprint,omitempty"`
+	Created         string `json:"created_at,omitempty"`
+}
+
+// CertificateRequest represents configuration for a new certificate.
+type CertificateRequest struct {
+	Name             string `json:"name,omitempty"`
+	PrivateKey       string `json:"private_key,omitempty"`
+	LeafCertificate  string `json:"leaf_certificate,omitempty"`
+	CertificateChain string `json:"certificate_chain,omitempty"`
+}
+
+type certificateRoot struct {
+	Certificate *Certificate `json:"certificate"`
+}
+
+type certificatesRoot struct {
+	Certificates []Certificate `json:"certificates"`
+	Links        *Links        `json:"links"`
+}
+
+// CertificatesServiceOp handles communication with certificates methods of the DigitalOcean API.
+type CertificatesServiceOp struct {
+	client *Client
+}
+
+var _ CertificatesService = &CertificatesServiceOp{}
+
+// Get an existing certificate by its identifier.
+func (c *CertificatesServiceOp) Get(ctx context.Context, cID string) (*Certificate, *Response, error) {
+	urlStr := path.Join(certificatesBasePath, cID)
+
+	req, err := c.client.NewRequest(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(certificateRoot)
+	resp, err := c.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Certificate, resp, nil
+}
+
+// List all certificates.
+func (c *CertificatesServiceOp) List(ctx context.Context, opt *ListOptions) ([]Certificate, *Response, error) {
+	urlStr, err := addOptions(certificatesBasePath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := c.client.NewRequest(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(certificatesRoot)
+	resp, err := c.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Certificates, resp, nil
+}
+
+// Create a new certificate with provided configuration.
+func (c *CertificatesServiceOp) Create(ctx context.Context, cr *CertificateRequest) (*Certificate, *Response, error) {
+	req, err := c.client.NewRequest(ctx, http.MethodPost, certificatesBasePath, cr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(certificateRoot)
+	resp, err := c.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Certificate, resp, nil
+}
+
+// Delete a certificate by its identifier.
+func (c *CertificatesServiceOp) Delete(ctx context.Context, cID string) (*Response, error) {
+	urlStr := path.Join(certificatesBasePath, cID)
+
+	req, err := c.client.NewRequest(ctx, http.MethodDelete, urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.client.Do(ctx, req, nil)
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/doc.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/doc.go
@@ -1,0 +1,2 @@
+// Package godo is the DigtalOcean API v2 client for Go
+package godo

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/domains.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/domains.go
@@ -1,0 +1,330 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const domainsBasePath = "v2/domains"
+
+// DomainsService is an interface for managing DNS with the DigitalOcean API.
+// See: https://developers.digitalocean.com/documentation/v2#domains and
+// https://developers.digitalocean.com/documentation/v2#domain-records
+type DomainsService interface {
+	List(context.Context, *ListOptions) ([]Domain, *Response, error)
+	Get(context.Context, string) (*Domain, *Response, error)
+	Create(context.Context, *DomainCreateRequest) (*Domain, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+
+	Records(context.Context, string, *ListOptions) ([]DomainRecord, *Response, error)
+	Record(context.Context, string, int) (*DomainRecord, *Response, error)
+	DeleteRecord(context.Context, string, int) (*Response, error)
+	EditRecord(context.Context, string, int, *DomainRecordEditRequest) (*DomainRecord, *Response, error)
+	CreateRecord(context.Context, string, *DomainRecordEditRequest) (*DomainRecord, *Response, error)
+}
+
+// DomainsServiceOp handles communication with the domain related methods of the
+// DigitalOcean API.
+type DomainsServiceOp struct {
+	client *Client
+}
+
+var _ DomainsService = &DomainsServiceOp{}
+
+// Domain represents a DigitalOcean domain
+type Domain struct {
+	Name     string `json:"name"`
+	TTL      int    `json:"ttl"`
+	ZoneFile string `json:"zone_file"`
+}
+
+// domainRoot represents a response from the DigitalOcean API
+type domainRoot struct {
+	Domain *Domain `json:"domain"`
+}
+
+type domainsRoot struct {
+	Domains []Domain `json:"domains"`
+	Links   *Links   `json:"links"`
+}
+
+// DomainCreateRequest respresents a request to create a domain.
+type DomainCreateRequest struct {
+	Name      string `json:"name"`
+	IPAddress string `json:"ip_address"`
+}
+
+// DomainRecordRoot is the root of an individual Domain Record response
+type domainRecordRoot struct {
+	DomainRecord *DomainRecord `json:"domain_record"`
+}
+
+// DomainRecordsRoot is the root of a group of Domain Record responses
+type domainRecordsRoot struct {
+	DomainRecords []DomainRecord `json:"domain_records"`
+	Links         *Links         `json:"links"`
+}
+
+// DomainRecord represents a DigitalOcean DomainRecord
+type DomainRecord struct {
+	ID       int    `json:"id,float64,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Data     string `json:"data,omitempty"`
+	Priority int    `json:"priority,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	TTL      int    `json:"ttl,omitempty"`
+	Weight   int    `json:"weight,omitempty"`
+}
+
+// DomainRecordEditRequest represents a request to update a domain record.
+type DomainRecordEditRequest struct {
+	Type     string `json:"type,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Data     string `json:"data,omitempty"`
+	Priority int    `json:"priority,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	TTL      int    `json:"ttl,omitempty"`
+	Weight   int    `json:"weight,omitempty"`
+}
+
+func (d Domain) String() string {
+	return Stringify(d)
+}
+
+// List all domains.
+func (s DomainsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Domain, *Response, error) {
+	path := domainsBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(domainsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Domains, resp, err
+}
+
+// Get individual domain. It requires a non-empty domain name.
+func (s *DomainsServiceOp) Get(ctx context.Context, name string) (*Domain, *Response, error) {
+	if len(name) < 1 {
+		return nil, nil, NewArgError("name", "cannot be an empty string")
+	}
+
+	path := fmt.Sprintf("%s/%s", domainsBasePath, name)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(domainRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Domain, resp, err
+}
+
+// Create a new domain
+func (s *DomainsServiceOp) Create(ctx context.Context, createRequest *DomainCreateRequest) (*Domain, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := domainsBasePath
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(domainRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Domain, resp, err
+}
+
+// Delete domain
+func (s *DomainsServiceOp) Delete(ctx context.Context, name string) (*Response, error) {
+	if len(name) < 1 {
+		return nil, NewArgError("name", "cannot be an empty string")
+	}
+
+	path := fmt.Sprintf("%s/%s", domainsBasePath, name)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// Converts a DomainRecord to a string.
+func (d DomainRecord) String() string {
+	return Stringify(d)
+}
+
+// Converts a DomainRecordEditRequest to a string.
+func (d DomainRecordEditRequest) String() string {
+	return Stringify(d)
+}
+
+// Records returns a slice of DomainRecords for a domain
+func (s *DomainsServiceOp) Records(ctx context.Context, domain string, opt *ListOptions) ([]DomainRecord, *Response, error) {
+	if len(domain) < 1 {
+		return nil, nil, NewArgError("domain", "cannot be an empty string")
+	}
+
+	path := fmt.Sprintf("%s/%s/records", domainsBasePath, domain)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(domainRecordsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.DomainRecords, resp, err
+}
+
+// Record returns the record id from a domain
+func (s *DomainsServiceOp) Record(ctx context.Context, domain string, id int) (*DomainRecord, *Response, error) {
+	if len(domain) < 1 {
+		return nil, nil, NewArgError("domain", "cannot be an empty string")
+	}
+
+	if id < 1 {
+		return nil, nil, NewArgError("id", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%s/records/%d", domainsBasePath, domain, id)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	record := new(domainRecordRoot)
+	resp, err := s.client.Do(ctx, req, record)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return record.DomainRecord, resp, err
+}
+
+// DeleteRecord deletes a record from a domain identified by id
+func (s *DomainsServiceOp) DeleteRecord(ctx context.Context, domain string, id int) (*Response, error) {
+	if len(domain) < 1 {
+		return nil, NewArgError("domain", "cannot be an empty string")
+	}
+
+	if id < 1 {
+		return nil, NewArgError("id", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%s/records/%d", domainsBasePath, domain, id)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// EditRecord edits a record using a DomainRecordEditRequest
+func (s *DomainsServiceOp) EditRecord(ctx context.Context,
+	domain string,
+	id int,
+	editRequest *DomainRecordEditRequest,
+) (*DomainRecord, *Response, error) {
+	if len(domain) < 1 {
+		return nil, nil, NewArgError("domain", "cannot be an empty string")
+	}
+
+	if id < 1 {
+		return nil, nil, NewArgError("id", "cannot be less than 1")
+	}
+
+	if editRequest == nil {
+		return nil, nil, NewArgError("editRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("%s/%s/records/%d", domainsBasePath, domain, id)
+
+	req, err := s.client.NewRequest(ctx, "PUT", path, editRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	d := new(DomainRecord)
+	resp, err := s.client.Do(ctx, req, d)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return d, resp, err
+}
+
+// CreateRecord creates a record using a DomainRecordEditRequest
+func (s *DomainsServiceOp) CreateRecord(ctx context.Context,
+	domain string,
+	createRequest *DomainRecordEditRequest) (*DomainRecord, *Response, error) {
+	if len(domain) < 1 {
+		return nil, nil, NewArgError("domain", "cannot be empty string")
+	}
+
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("%s/%s/records", domainsBasePath, domain)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	d := new(domainRecordRoot)
+	resp, err := s.client.Do(ctx, req, d)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return d.DomainRecord, resp, err
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/droplet_actions.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/droplet_actions.go
@@ -1,0 +1,337 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/digitalocean/godo/context"
+)
+
+// ActionRequest reprents DigitalOcean Action Request
+type ActionRequest map[string]interface{}
+
+// DropletActionsService is an interface for interfacing with the Droplet actions
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2#droplet-actions
+type DropletActionsService interface {
+	Shutdown(context.Context, int) (*Action, *Response, error)
+	ShutdownByTag(context.Context, string) ([]Action, *Response, error)
+	PowerOff(context.Context, int) (*Action, *Response, error)
+	PowerOffByTag(context.Context, string) ([]Action, *Response, error)
+	PowerOn(context.Context, int) (*Action, *Response, error)
+	PowerOnByTag(context.Context, string) ([]Action, *Response, error)
+	PowerCycle(context.Context, int) (*Action, *Response, error)
+	PowerCycleByTag(context.Context, string) ([]Action, *Response, error)
+	Reboot(context.Context, int) (*Action, *Response, error)
+	Restore(context.Context, int, int) (*Action, *Response, error)
+	Resize(context.Context, int, string, bool) (*Action, *Response, error)
+	Rename(context.Context, int, string) (*Action, *Response, error)
+	Snapshot(context.Context, int, string) (*Action, *Response, error)
+	SnapshotByTag(context.Context, string, string) ([]Action, *Response, error)
+	EnableBackups(context.Context, int) (*Action, *Response, error)
+	EnableBackupsByTag(context.Context, string) ([]Action, *Response, error)
+	DisableBackups(context.Context, int) (*Action, *Response, error)
+	DisableBackupsByTag(context.Context, string) ([]Action, *Response, error)
+	PasswordReset(context.Context, int) (*Action, *Response, error)
+	RebuildByImageID(context.Context, int, int) (*Action, *Response, error)
+	RebuildByImageSlug(context.Context, int, string) (*Action, *Response, error)
+	ChangeKernel(context.Context, int, int) (*Action, *Response, error)
+	EnableIPv6(context.Context, int) (*Action, *Response, error)
+	EnableIPv6ByTag(context.Context, string) ([]Action, *Response, error)
+	EnablePrivateNetworking(context.Context, int) (*Action, *Response, error)
+	EnablePrivateNetworkingByTag(context.Context, string) ([]Action, *Response, error)
+	Upgrade(context.Context, int) (*Action, *Response, error)
+	Get(context.Context, int, int) (*Action, *Response, error)
+	GetByURI(context.Context, string) (*Action, *Response, error)
+}
+
+// DropletActionsServiceOp handles communication with the Droplet action related
+// methods of the DigitalOcean API.
+type DropletActionsServiceOp struct {
+	client *Client
+}
+
+var _ DropletActionsService = &DropletActionsServiceOp{}
+
+// Shutdown a Droplet
+func (s *DropletActionsServiceOp) Shutdown(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "shutdown"}
+	return s.doAction(ctx, id, request)
+}
+
+// ShutdownByTag shuts down Droplets matched by a Tag.
+func (s *DropletActionsServiceOp) ShutdownByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
+	request := &ActionRequest{"type": "shutdown"}
+	return s.doActionByTag(ctx, tag, request)
+}
+
+// PowerOff a Droplet
+func (s *DropletActionsServiceOp) PowerOff(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "power_off"}
+	return s.doAction(ctx, id, request)
+}
+
+// PowerOffByTag powers off Droplets matched by a Tag.
+func (s *DropletActionsServiceOp) PowerOffByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
+	request := &ActionRequest{"type": "power_off"}
+	return s.doActionByTag(ctx, tag, request)
+}
+
+// PowerOn a Droplet
+func (s *DropletActionsServiceOp) PowerOn(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "power_on"}
+	return s.doAction(ctx, id, request)
+}
+
+// PowerOnByTag powers on Droplets matched by a Tag.
+func (s *DropletActionsServiceOp) PowerOnByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
+	request := &ActionRequest{"type": "power_on"}
+	return s.doActionByTag(ctx, tag, request)
+}
+
+// PowerCycle a Droplet
+func (s *DropletActionsServiceOp) PowerCycle(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "power_cycle"}
+	return s.doAction(ctx, id, request)
+}
+
+// PowerCycleByTag power cycles Droplets matched by a Tag.
+func (s *DropletActionsServiceOp) PowerCycleByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
+	request := &ActionRequest{"type": "power_cycle"}
+	return s.doActionByTag(ctx, tag, request)
+}
+
+// Reboot a Droplet
+func (s *DropletActionsServiceOp) Reboot(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "reboot"}
+	return s.doAction(ctx, id, request)
+}
+
+// Restore an image to a Droplet
+func (s *DropletActionsServiceOp) Restore(ctx context.Context, id, imageID int) (*Action, *Response, error) {
+	requestType := "restore"
+	request := &ActionRequest{
+		"type":  requestType,
+		"image": float64(imageID),
+	}
+	return s.doAction(ctx, id, request)
+}
+
+// Resize a Droplet
+func (s *DropletActionsServiceOp) Resize(ctx context.Context, id int, sizeSlug string, resizeDisk bool) (*Action, *Response, error) {
+	requestType := "resize"
+	request := &ActionRequest{
+		"type": requestType,
+		"size": sizeSlug,
+		"disk": resizeDisk,
+	}
+	return s.doAction(ctx, id, request)
+}
+
+// Rename a Droplet
+func (s *DropletActionsServiceOp) Rename(ctx context.Context, id int, name string) (*Action, *Response, error) {
+	requestType := "rename"
+	request := &ActionRequest{
+		"type": requestType,
+		"name": name,
+	}
+	return s.doAction(ctx, id, request)
+}
+
+// Snapshot a Droplet.
+func (s *DropletActionsServiceOp) Snapshot(ctx context.Context, id int, name string) (*Action, *Response, error) {
+	requestType := "snapshot"
+	request := &ActionRequest{
+		"type": requestType,
+		"name": name,
+	}
+	return s.doAction(ctx, id, request)
+}
+
+// SnapshotByTag snapshots Droplets matched by a Tag.
+func (s *DropletActionsServiceOp) SnapshotByTag(ctx context.Context, tag string, name string) ([]Action, *Response, error) {
+	requestType := "snapshot"
+	request := &ActionRequest{
+		"type": requestType,
+		"name": name,
+	}
+	return s.doActionByTag(ctx, tag, request)
+}
+
+// EnableBackups enables backups for a Droplet.
+func (s *DropletActionsServiceOp) EnableBackups(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "enable_backups"}
+	return s.doAction(ctx, id, request)
+}
+
+// EnableBackupsByTag enables backups for Droplets matched by a Tag.
+func (s *DropletActionsServiceOp) EnableBackupsByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
+	request := &ActionRequest{"type": "enable_backups"}
+	return s.doActionByTag(ctx, tag, request)
+}
+
+// DisableBackups disables backups for a Droplet.
+func (s *DropletActionsServiceOp) DisableBackups(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "disable_backups"}
+	return s.doAction(ctx, id, request)
+}
+
+// DisableBackupsByTag disables backups for Droplet matched by a Tag.
+func (s *DropletActionsServiceOp) DisableBackupsByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
+	request := &ActionRequest{"type": "disable_backups"}
+	return s.doActionByTag(ctx, tag, request)
+}
+
+// PasswordReset resets the password for a Droplet.
+func (s *DropletActionsServiceOp) PasswordReset(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "password_reset"}
+	return s.doAction(ctx, id, request)
+}
+
+// RebuildByImageID rebuilds a Droplet from an image with a given id.
+func (s *DropletActionsServiceOp) RebuildByImageID(ctx context.Context, id, imageID int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "rebuild", "image": imageID}
+	return s.doAction(ctx, id, request)
+}
+
+// RebuildByImageSlug rebuilds a Droplet from an Image matched by a given Slug.
+func (s *DropletActionsServiceOp) RebuildByImageSlug(ctx context.Context, id int, slug string) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "rebuild", "image": slug}
+	return s.doAction(ctx, id, request)
+}
+
+// ChangeKernel changes the kernel for a Droplet.
+func (s *DropletActionsServiceOp) ChangeKernel(ctx context.Context, id, kernelID int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "change_kernel", "kernel": kernelID}
+	return s.doAction(ctx, id, request)
+}
+
+// EnableIPv6 enables IPv6 for a Droplet.
+func (s *DropletActionsServiceOp) EnableIPv6(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "enable_ipv6"}
+	return s.doAction(ctx, id, request)
+}
+
+// EnableIPv6ByTag enables IPv6 for Droplets matched by a Tag.
+func (s *DropletActionsServiceOp) EnableIPv6ByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
+	request := &ActionRequest{"type": "enable_ipv6"}
+	return s.doActionByTag(ctx, tag, request)
+}
+
+// EnablePrivateNetworking enables private networking for a Droplet.
+func (s *DropletActionsServiceOp) EnablePrivateNetworking(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "enable_private_networking"}
+	return s.doAction(ctx, id, request)
+}
+
+// EnablePrivateNetworkingByTag enables private networking for Droplets matched by a Tag.
+func (s *DropletActionsServiceOp) EnablePrivateNetworkingByTag(ctx context.Context, tag string) ([]Action, *Response, error) {
+	request := &ActionRequest{"type": "enable_private_networking"}
+	return s.doActionByTag(ctx, tag, request)
+}
+
+// Upgrade a Droplet.
+func (s *DropletActionsServiceOp) Upgrade(ctx context.Context, id int) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "upgrade"}
+	return s.doAction(ctx, id, request)
+}
+
+func (s *DropletActionsServiceOp) doAction(ctx context.Context, id int, request *ActionRequest) (*Action, *Response, error) {
+	if id < 1 {
+		return nil, nil, NewArgError("id", "cannot be less than 1")
+	}
+
+	if request == nil {
+		return nil, nil, NewArgError("request", "request can't be nil")
+	}
+
+	path := dropletActionPath(id)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+func (s *DropletActionsServiceOp) doActionByTag(ctx context.Context, tag string, request *ActionRequest) ([]Action, *Response, error) {
+	if tag == "" {
+		return nil, nil, NewArgError("tag", "cannot be empty")
+	}
+
+	if request == nil {
+		return nil, nil, NewArgError("request", "request can't be nil")
+	}
+
+	path := dropletActionPathByTag(tag)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Actions, resp, err
+}
+
+// Get an action for a particular Droplet by id.
+func (s *DropletActionsServiceOp) Get(ctx context.Context, dropletID, actionID int) (*Action, *Response, error) {
+	if dropletID < 1 {
+		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
+	}
+
+	if actionID < 1 {
+		return nil, nil, NewArgError("actionID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d", dropletActionPath(dropletID), actionID)
+	return s.get(ctx, path)
+}
+
+// GetByURI gets an action for a particular Droplet by id.
+func (s *DropletActionsServiceOp) GetByURI(ctx context.Context, rawurl string) (*Action, *Response, error) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.get(ctx, u.Path)
+
+}
+
+func (s *DropletActionsServiceOp) get(ctx context.Context, path string) (*Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+
+}
+
+func dropletActionPath(dropletID int) string {
+	return fmt.Sprintf("v2/droplets/%d/actions", dropletID)
+}
+
+func dropletActionPathByTag(tag string) string {
+	return fmt.Sprintf("v2/droplets/actions?tag_name=%s", tag)
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/droplets.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/droplets.go
@@ -1,0 +1,567 @@
+package godo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const dropletBasePath = "v2/droplets"
+
+var errNoNetworks = errors.New("no networks have been defined")
+
+// DropletsService is an interface for interfacing with the Droplet
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2#droplets
+type DropletsService interface {
+	List(context.Context, *ListOptions) ([]Droplet, *Response, error)
+	ListByTag(context.Context, string, *ListOptions) ([]Droplet, *Response, error)
+	Get(context.Context, int) (*Droplet, *Response, error)
+	Create(context.Context, *DropletCreateRequest) (*Droplet, *Response, error)
+	CreateMultiple(context.Context, *DropletMultiCreateRequest) ([]Droplet, *Response, error)
+	Delete(context.Context, int) (*Response, error)
+	DeleteByTag(context.Context, string) (*Response, error)
+	Kernels(context.Context, int, *ListOptions) ([]Kernel, *Response, error)
+	Snapshots(context.Context, int, *ListOptions) ([]Image, *Response, error)
+	Backups(context.Context, int, *ListOptions) ([]Image, *Response, error)
+	Actions(context.Context, int, *ListOptions) ([]Action, *Response, error)
+	Neighbors(context.Context, int) ([]Droplet, *Response, error)
+}
+
+// DropletsServiceOp handles communication with the Droplet related methods of the
+// DigitalOcean API.
+type DropletsServiceOp struct {
+	client *Client
+}
+
+var _ DropletsService = &DropletsServiceOp{}
+
+// Droplet represents a DigitalOcean Droplet
+type Droplet struct {
+	ID               int           `json:"id,float64,omitempty"`
+	Name             string        `json:"name,omitempty"`
+	Memory           int           `json:"memory,omitempty"`
+	Vcpus            int           `json:"vcpus,omitempty"`
+	Disk             int           `json:"disk,omitempty"`
+	Region           *Region       `json:"region,omitempty"`
+	Image            *Image        `json:"image,omitempty"`
+	Size             *Size         `json:"size,omitempty"`
+	SizeSlug         string        `json:"size_slug,omitempty"`
+	BackupIDs        []int         `json:"backup_ids,omitempty"`
+	NextBackupWindow *BackupWindow `json:"next_backup_window,omitempty"`
+	SnapshotIDs      []int         `json:"snapshot_ids,omitempty"`
+	Features         []string      `json:"features,omitempty"`
+	Locked           bool          `json:"locked,bool,omitempty"`
+	Status           string        `json:"status,omitempty"`
+	Networks         *Networks     `json:"networks,omitempty"`
+	Created          string        `json:"created_at,omitempty"`
+	Kernel           *Kernel       `json:"kernel,omitempty"`
+	Tags             []string      `json:"tags,omitempty"`
+	VolumeIDs        []string      `json:"volume_ids"`
+}
+
+// PublicIPv4 returns the public IPv4 address for the Droplet.
+func (d *Droplet) PublicIPv4() (string, error) {
+	if d.Networks == nil {
+		return "", errNoNetworks
+	}
+
+	for _, v4 := range d.Networks.V4 {
+		if v4.Type == "public" {
+			return v4.IPAddress, nil
+		}
+	}
+
+	return "", nil
+}
+
+// PrivateIPv4 returns the private IPv4 address for the Droplet.
+func (d *Droplet) PrivateIPv4() (string, error) {
+	if d.Networks == nil {
+		return "", errNoNetworks
+	}
+
+	for _, v4 := range d.Networks.V4 {
+		if v4.Type == "private" {
+			return v4.IPAddress, nil
+		}
+	}
+
+	return "", nil
+}
+
+// PublicIPv6 returns the public IPv6 address for the Droplet.
+func (d *Droplet) PublicIPv6() (string, error) {
+	if d.Networks == nil {
+		return "", errNoNetworks
+	}
+
+	for _, v6 := range d.Networks.V6 {
+		if v6.Type == "public" {
+			return v6.IPAddress, nil
+		}
+	}
+
+	return "", nil
+}
+
+// Kernel object
+type Kernel struct {
+	ID      int    `json:"id,float64,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// BackupWindow object
+type BackupWindow struct {
+	Start *Timestamp `json:"start,omitempty"`
+	End   *Timestamp `json:"end,omitempty"`
+}
+
+// Convert Droplet to a string
+func (d Droplet) String() string {
+	return Stringify(d)
+}
+
+// DropletRoot represents a Droplet root
+type dropletRoot struct {
+	Droplet *Droplet `json:"droplet"`
+	Links   *Links   `json:"links,omitempty"`
+}
+
+type dropletsRoot struct {
+	Droplets []Droplet `json:"droplets"`
+	Links    *Links    `json:"links"`
+}
+
+type kernelsRoot struct {
+	Kernels []Kernel `json:"kernels,omitempty"`
+	Links   *Links   `json:"links"`
+}
+
+type dropletSnapshotsRoot struct {
+	Snapshots []Image `json:"snapshots,omitempty"`
+	Links     *Links  `json:"links"`
+}
+
+type backupsRoot struct {
+	Backups []Image `json:"backups,omitempty"`
+	Links   *Links  `json:"links"`
+}
+
+// DropletCreateImage identifies an image for the create request. It prefers slug over ID.
+type DropletCreateImage struct {
+	ID   int
+	Slug string
+}
+
+// MarshalJSON returns either the slug or id of the image. It returns the id
+// if the slug is empty.
+func (d DropletCreateImage) MarshalJSON() ([]byte, error) {
+	if d.Slug != "" {
+		return json.Marshal(d.Slug)
+	}
+
+	return json.Marshal(d.ID)
+}
+
+// DropletCreateVolume identifies a volume to attach for the create request. It
+// prefers Name over ID,
+type DropletCreateVolume struct {
+	ID   string
+	Name string
+}
+
+// MarshalJSON returns an object with either the name or id of the volume. It
+// returns the id if the name is empty.
+func (d DropletCreateVolume) MarshalJSON() ([]byte, error) {
+	if d.Name != "" {
+		return json.Marshal(struct {
+			Name string `json:"name"`
+		}{Name: d.Name})
+	}
+
+	return json.Marshal(struct {
+		ID string `json:"id"`
+	}{ID: d.ID})
+}
+
+// DropletCreateSSHKey identifies a SSH Key for the create request. It prefers fingerprint over ID.
+type DropletCreateSSHKey struct {
+	ID          int
+	Fingerprint string
+}
+
+// MarshalJSON returns either the fingerprint or id of the ssh key. It returns
+// the id if the fingerprint is empty.
+func (d DropletCreateSSHKey) MarshalJSON() ([]byte, error) {
+	if d.Fingerprint != "" {
+		return json.Marshal(d.Fingerprint)
+	}
+
+	return json.Marshal(d.ID)
+}
+
+// DropletCreateRequest represents a request to create a Droplet.
+type DropletCreateRequest struct {
+	Name              string                `json:"name"`
+	Region            string                `json:"region"`
+	Size              string                `json:"size"`
+	Image             DropletCreateImage    `json:"image"`
+	SSHKeys           []DropletCreateSSHKey `json:"ssh_keys"`
+	Backups           bool                  `json:"backups"`
+	IPv6              bool                  `json:"ipv6"`
+	PrivateNetworking bool                  `json:"private_networking"`
+	Monitoring        bool                  `json:"monitoring"`
+	UserData          string                `json:"user_data,omitempty"`
+	Volumes           []DropletCreateVolume `json:"volumes,omitempty"`
+	Tags              []string              `json:"tags"`
+}
+
+// DropletMultiCreateRequest is a request to create multiple Droplets.
+type DropletMultiCreateRequest struct {
+	Names             []string              `json:"names"`
+	Region            string                `json:"region"`
+	Size              string                `json:"size"`
+	Image             DropletCreateImage    `json:"image"`
+	SSHKeys           []DropletCreateSSHKey `json:"ssh_keys"`
+	Backups           bool                  `json:"backups"`
+	IPv6              bool                  `json:"ipv6"`
+	PrivateNetworking bool                  `json:"private_networking"`
+	Monitoring        bool                  `json:"monitoring"`
+	UserData          string                `json:"user_data,omitempty"`
+	Tags              []string              `json:"tags"`
+}
+
+func (d DropletCreateRequest) String() string {
+	return Stringify(d)
+}
+
+func (d DropletMultiCreateRequest) String() string {
+	return Stringify(d)
+}
+
+// Networks represents the Droplet's Networks.
+type Networks struct {
+	V4 []NetworkV4 `json:"v4,omitempty"`
+	V6 []NetworkV6 `json:"v6,omitempty"`
+}
+
+// NetworkV4 represents a DigitalOcean IPv4 Network.
+type NetworkV4 struct {
+	IPAddress string `json:"ip_address,omitempty"`
+	Netmask   string `json:"netmask,omitempty"`
+	Gateway   string `json:"gateway,omitempty"`
+	Type      string `json:"type,omitempty"`
+}
+
+func (n NetworkV4) String() string {
+	return Stringify(n)
+}
+
+// NetworkV6 represents a DigitalOcean IPv6 network.
+type NetworkV6 struct {
+	IPAddress string `json:"ip_address,omitempty"`
+	Netmask   int    `json:"netmask,omitempty"`
+	Gateway   string `json:"gateway,omitempty"`
+	Type      string `json:"type,omitempty"`
+}
+
+func (n NetworkV6) String() string {
+	return Stringify(n)
+}
+
+// Performs a list request given a path.
+func (s *DropletsServiceOp) list(ctx context.Context, path string) ([]Droplet, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(dropletsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Droplets, resp, err
+}
+
+// List all Droplets.
+func (s *DropletsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Droplet, *Response, error) {
+	path := dropletBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.list(ctx, path)
+}
+
+// ListByTag lists all Droplets matched by a Tag.
+func (s *DropletsServiceOp) ListByTag(ctx context.Context, tag string, opt *ListOptions) ([]Droplet, *Response, error) {
+	path := fmt.Sprintf("%s?tag_name=%s", dropletBasePath, tag)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.list(ctx, path)
+}
+
+// Get individual Droplet.
+func (s *DropletsServiceOp) Get(ctx context.Context, dropletID int) (*Droplet, *Response, error) {
+	if dropletID < 1 {
+		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d", dropletBasePath, dropletID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(dropletRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Droplet, resp, err
+}
+
+// Create Droplet
+func (s *DropletsServiceOp) Create(ctx context.Context, createRequest *DropletCreateRequest) (*Droplet, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := dropletBasePath
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(dropletRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Droplet, resp, err
+}
+
+// CreateMultiple creates multiple Droplets.
+func (s *DropletsServiceOp) CreateMultiple(ctx context.Context, createRequest *DropletMultiCreateRequest) ([]Droplet, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := dropletBasePath
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(dropletsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Droplets, resp, err
+}
+
+// Performs a delete request given a path
+func (s *DropletsServiceOp) delete(ctx context.Context, path string) (*Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// Delete Droplet.
+func (s *DropletsServiceOp) Delete(ctx context.Context, dropletID int) (*Response, error) {
+	if dropletID < 1 {
+		return nil, NewArgError("dropletID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d", dropletBasePath, dropletID)
+
+	return s.delete(ctx, path)
+}
+
+// DeleteByTag deletes Droplets matched by a Tag.
+func (s *DropletsServiceOp) DeleteByTag(ctx context.Context, tag string) (*Response, error) {
+	if tag == "" {
+		return nil, NewArgError("tag", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s?tag_name=%s", dropletBasePath, tag)
+
+	return s.delete(ctx, path)
+}
+
+// Kernels lists kernels available for a Droplet.
+func (s *DropletsServiceOp) Kernels(ctx context.Context, dropletID int, opt *ListOptions) ([]Kernel, *Response, error) {
+	if dropletID < 1 {
+		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d/kernels", dropletBasePath, dropletID)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(kernelsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Kernels, resp, err
+}
+
+// Actions lists the actions for a Droplet.
+func (s *DropletsServiceOp) Actions(ctx context.Context, dropletID int, opt *ListOptions) ([]Action, *Response, error) {
+	if dropletID < 1 {
+		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d/actions", dropletBasePath, dropletID)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Actions, resp, err
+}
+
+// Backups lists the backups for a Droplet.
+func (s *DropletsServiceOp) Backups(ctx context.Context, dropletID int, opt *ListOptions) ([]Image, *Response, error) {
+	if dropletID < 1 {
+		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d/backups", dropletBasePath, dropletID)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(backupsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Backups, resp, err
+}
+
+// Snapshots lists the snapshots available for a Droplet.
+func (s *DropletsServiceOp) Snapshots(ctx context.Context, dropletID int, opt *ListOptions) ([]Image, *Response, error) {
+	if dropletID < 1 {
+		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d/snapshots", dropletBasePath, dropletID)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(dropletSnapshotsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Snapshots, resp, err
+}
+
+// Neighbors lists the neighbors for a Droplet.
+func (s *DropletsServiceOp) Neighbors(ctx context.Context, dropletID int) ([]Droplet, *Response, error) {
+	if dropletID < 1 {
+		return nil, nil, NewArgError("dropletID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d/neighbors", dropletBasePath, dropletID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(dropletsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Droplets, resp, err
+}
+
+func (s *DropletsServiceOp) dropletActionStatus(ctx context.Context, uri string) (string, error) {
+	action, _, err := s.client.DropletActions.GetByURI(ctx, uri)
+
+	if err != nil {
+		return "", err
+	}
+
+	return action.Status, nil
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/errors.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/errors.go
@@ -1,0 +1,24 @@
+package godo
+
+import "fmt"
+
+// ArgError is an error that represents an error with an input to godo. It
+// identifies the argument and the cause (if possible).
+type ArgError struct {
+	arg    string
+	reason string
+}
+
+var _ error = &ArgError{}
+
+// NewArgError creates an InputError.
+func NewArgError(arg, reason string) *ArgError {
+	return &ArgError{
+		arg:    arg,
+		reason: reason,
+	}
+}
+
+func (e *ArgError) Error() string {
+	return fmt.Sprintf("%s is invalid because %s", e.arg, e.reason)
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/firewalls.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/firewalls.go
@@ -1,0 +1,264 @@
+package godo
+
+import (
+	"net/http"
+	"path"
+	"strconv"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const firewallsBasePath = "/v2/firewalls"
+
+// FirewallsService is an interface for managing Firewalls with the DigitalOcean API.
+// See: https://developers.digitalocean.com/documentation/documentation/v2/#firewalls
+type FirewallsService interface {
+	Get(context.Context, string) (*Firewall, *Response, error)
+	Create(context.Context, *FirewallRequest) (*Firewall, *Response, error)
+	Update(context.Context, string, *FirewallRequest) (*Firewall, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+	List(context.Context, *ListOptions) ([]Firewall, *Response, error)
+	ListByDroplet(context.Context, int, *ListOptions) ([]Firewall, *Response, error)
+	AddDroplets(context.Context, string, ...int) (*Response, error)
+	RemoveDroplets(context.Context, string, ...int) (*Response, error)
+	AddTags(context.Context, string, ...string) (*Response, error)
+	RemoveTags(context.Context, string, ...string) (*Response, error)
+	AddRules(context.Context, string, *FirewallRulesRequest) (*Response, error)
+	RemoveRules(context.Context, string, *FirewallRulesRequest) (*Response, error)
+}
+
+// FirewallsServiceOp handles communication with Firewalls methods of the DigitalOcean API.
+type FirewallsServiceOp struct {
+	client *Client
+}
+
+// Firewall represents a DigitalOcean Firewall configuration.
+type Firewall struct {
+	ID             string          `json:"id"`
+	Name           string          `json:"name"`
+	Status         string          `json:"status"`
+	InboundRules   []InboundRule   `json:"inbound_rules"`
+	OutboundRules  []OutboundRule  `json:"outbound_rules"`
+	DropletIDs     []int           `json:"droplet_ids"`
+	Tags           []string        `json:"tags"`
+	Created        string          `json:"created_at"`
+	PendingChanges []PendingChange `json:"pending_changes"`
+}
+
+// String creates a human-readable description of a Firewall.
+func (fw Firewall) String() string {
+	return Stringify(fw)
+}
+
+// FirewallRequest represents the configuration to be applied to an existing or a new Firewall.
+type FirewallRequest struct {
+	Name          string         `json:"name"`
+	InboundRules  []InboundRule  `json:"inbound_rules"`
+	OutboundRules []OutboundRule `json:"outbound_rules"`
+	DropletIDs    []int          `json:"droplet_ids"`
+	Tags          []string       `json:"tags"`
+}
+
+// FirewallRulesRequest represents rules configuration to be applied to an existing Firewall.
+type FirewallRulesRequest struct {
+	InboundRules  []InboundRule  `json:"inbound_rules"`
+	OutboundRules []OutboundRule `json:"outbound_rules"`
+}
+
+// InboundRule represents a DigitalOcean Firewall inbound rule.
+type InboundRule struct {
+	Protocol  string   `json:"protocol,omitempty"`
+	PortRange string   `json:"ports,omitempty"`
+	Sources   *Sources `json:"sources"`
+}
+
+// OutboundRule represents a DigitalOcean Firewall outbound rule.
+type OutboundRule struct {
+	Protocol     string        `json:"protocol,omitempty"`
+	PortRange    string        `json:"ports,omitempty"`
+	Destinations *Destinations `json:"destinations"`
+}
+
+// Sources represents a DigitalOcean Firewall InboundRule sources.
+type Sources struct {
+	Addresses        []string `json:"addresses,omitempty"`
+	Tags             []string `json:"tags,omitempty"`
+	DropletIDs       []int    `json:"droplet_ids,omitempty"`
+	LoadBalancerUIDs []string `json:"load_balancer_uids,omitempty"`
+}
+
+// PendingChange represents a DigitalOcean Firewall status details.
+type PendingChange struct {
+	DropletID int    `json:"droplet_id,omitempty"`
+	Removing  bool   `json:"removing,omitempty"`
+	Status    string `json:"status,omitempty"`
+}
+
+// Destinations represents a DigitalOcean Firewall OutboundRule destinations.
+type Destinations struct {
+	Addresses        []string `json:"addresses,omitempty"`
+	Tags             []string `json:"tags,omitempty"`
+	DropletIDs       []int    `json:"droplet_ids,omitempty"`
+	LoadBalancerUIDs []string `json:"load_balancer_uids,omitempty"`
+}
+
+var _ FirewallsService = &FirewallsServiceOp{}
+
+// Get an existing Firewall by its identifier.
+func (fw *FirewallsServiceOp) Get(ctx context.Context, fID string) (*Firewall, *Response, error) {
+	path := path.Join(firewallsBasePath, fID)
+
+	req, err := fw.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(firewallRoot)
+	resp, err := fw.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Firewall, resp, err
+}
+
+// Create a new Firewall with a given configuration.
+func (fw *FirewallsServiceOp) Create(ctx context.Context, fr *FirewallRequest) (*Firewall, *Response, error) {
+	req, err := fw.client.NewRequest(ctx, http.MethodPost, firewallsBasePath, fr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(firewallRoot)
+	resp, err := fw.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Firewall, resp, err
+}
+
+// Update an existing Firewall with new configuration.
+func (fw *FirewallsServiceOp) Update(ctx context.Context, fID string, fr *FirewallRequest) (*Firewall, *Response, error) {
+	path := path.Join(firewallsBasePath, fID)
+
+	req, err := fw.client.NewRequest(ctx, "PUT", path, fr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(firewallRoot)
+	resp, err := fw.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Firewall, resp, err
+}
+
+// Delete a Firewall by its identifier.
+func (fw *FirewallsServiceOp) Delete(ctx context.Context, fID string) (*Response, error) {
+	path := path.Join(firewallsBasePath, fID)
+	return fw.createAndDoReq(ctx, http.MethodDelete, path, nil)
+}
+
+// List Firewalls.
+func (fw *FirewallsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Firewall, *Response, error) {
+	path, err := addOptions(firewallsBasePath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return fw.listHelper(ctx, path)
+}
+
+// ListByDroplet Firewalls.
+func (fw *FirewallsServiceOp) ListByDroplet(ctx context.Context, dID int, opt *ListOptions) ([]Firewall, *Response, error) {
+	basePath := path.Join(dropletBasePath, strconv.Itoa(dID), "firewalls")
+	path, err := addOptions(basePath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return fw.listHelper(ctx, path)
+}
+
+// AddDroplets to a Firewall.
+func (fw *FirewallsServiceOp) AddDroplets(ctx context.Context, fID string, dropletIDs ...int) (*Response, error) {
+	path := path.Join(firewallsBasePath, fID, "droplets")
+	return fw.createAndDoReq(ctx, http.MethodPost, path, &dropletsRequest{IDs: dropletIDs})
+}
+
+// RemoveDroplets from a Firewall.
+func (fw *FirewallsServiceOp) RemoveDroplets(ctx context.Context, fID string, dropletIDs ...int) (*Response, error) {
+	path := path.Join(firewallsBasePath, fID, "droplets")
+	return fw.createAndDoReq(ctx, http.MethodDelete, path, &dropletsRequest{IDs: dropletIDs})
+}
+
+// AddTags to a Firewall.
+func (fw *FirewallsServiceOp) AddTags(ctx context.Context, fID string, tags ...string) (*Response, error) {
+	path := path.Join(firewallsBasePath, fID, "tags")
+	return fw.createAndDoReq(ctx, http.MethodPost, path, &tagsRequest{Tags: tags})
+}
+
+// RemoveTags from a Firewall.
+func (fw *FirewallsServiceOp) RemoveTags(ctx context.Context, fID string, tags ...string) (*Response, error) {
+	path := path.Join(firewallsBasePath, fID, "tags")
+	return fw.createAndDoReq(ctx, http.MethodDelete, path, &tagsRequest{Tags: tags})
+}
+
+// AddRules to a Firewall.
+func (fw *FirewallsServiceOp) AddRules(ctx context.Context, fID string, rr *FirewallRulesRequest) (*Response, error) {
+	path := path.Join(firewallsBasePath, fID, "rules")
+	return fw.createAndDoReq(ctx, http.MethodPost, path, rr)
+}
+
+// RemoveRules from a Firewall.
+func (fw *FirewallsServiceOp) RemoveRules(ctx context.Context, fID string, rr *FirewallRulesRequest) (*Response, error) {
+	path := path.Join(firewallsBasePath, fID, "rules")
+	return fw.createAndDoReq(ctx, http.MethodDelete, path, rr)
+}
+
+type dropletsRequest struct {
+	IDs []int `json:"droplet_ids"`
+}
+
+type tagsRequest struct {
+	Tags []string `json:"tags"`
+}
+
+type firewallRoot struct {
+	Firewall *Firewall `json:"firewall"`
+}
+
+type firewallsRoot struct {
+	Firewalls []Firewall `json:"firewalls"`
+	Links     *Links     `json:"links"`
+}
+
+func (fw *FirewallsServiceOp) createAndDoReq(ctx context.Context, method, path string, v interface{}) (*Response, error) {
+	req, err := fw.client.NewRequest(ctx, method, path, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return fw.client.Do(ctx, req, nil)
+}
+
+func (fw *FirewallsServiceOp) listHelper(ctx context.Context, path string) ([]Firewall, *Response, error) {
+	req, err := fw.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(firewallsRoot)
+	resp, err := fw.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Firewalls, resp, err
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/floating_ips.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/floating_ips.go
@@ -1,0 +1,136 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const floatingBasePath = "v2/floating_ips"
+
+// FloatingIPsService is an interface for interfacing with the floating IPs
+// endpoints of the Digital Ocean API.
+// See: https://developers.digitalocean.com/documentation/v2#floating-ips
+type FloatingIPsService interface {
+	List(context.Context, *ListOptions) ([]FloatingIP, *Response, error)
+	Get(context.Context, string) (*FloatingIP, *Response, error)
+	Create(context.Context, *FloatingIPCreateRequest) (*FloatingIP, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+}
+
+// FloatingIPsServiceOp handles communication with the floating IPs related methods of the
+// DigitalOcean API.
+type FloatingIPsServiceOp struct {
+	client *Client
+}
+
+var _ FloatingIPsService = &FloatingIPsServiceOp{}
+
+// FloatingIP represents a Digital Ocean floating IP.
+type FloatingIP struct {
+	Region  *Region  `json:"region"`
+	Droplet *Droplet `json:"droplet"`
+	IP      string   `json:"ip"`
+}
+
+func (f FloatingIP) String() string {
+	return Stringify(f)
+}
+
+type floatingIPsRoot struct {
+	FloatingIPs []FloatingIP `json:"floating_ips"`
+	Links       *Links       `json:"links"`
+}
+
+type floatingIPRoot struct {
+	FloatingIP *FloatingIP `json:"floating_ip"`
+	Links      *Links      `json:"links,omitempty"`
+}
+
+// FloatingIPCreateRequest represents a request to create a floating IP.
+// If DropletID is not empty, the floating IP will be assigned to the
+// droplet.
+type FloatingIPCreateRequest struct {
+	Region    string `json:"region"`
+	DropletID int    `json:"droplet_id,omitempty"`
+}
+
+// List all floating IPs.
+func (f *FloatingIPsServiceOp) List(ctx context.Context, opt *ListOptions) ([]FloatingIP, *Response, error) {
+	path := floatingBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := f.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(floatingIPsRoot)
+	resp, err := f.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.FloatingIPs, resp, err
+}
+
+// Get an individual floating IP.
+func (f *FloatingIPsServiceOp) Get(ctx context.Context, ip string) (*FloatingIP, *Response, error) {
+	path := fmt.Sprintf("%s/%s", floatingBasePath, ip)
+
+	req, err := f.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(floatingIPRoot)
+	resp, err := f.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.FloatingIP, resp, err
+}
+
+// Create a floating IP. If the DropletID field of the request is not empty,
+// the floating IP will also be assigned to the droplet.
+func (f *FloatingIPsServiceOp) Create(ctx context.Context, createRequest *FloatingIPCreateRequest) (*FloatingIP, *Response, error) {
+	path := floatingBasePath
+
+	req, err := f.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(floatingIPRoot)
+	resp, err := f.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.FloatingIP, resp, err
+}
+
+// Delete a floating IP.
+func (f *FloatingIPsServiceOp) Delete(ctx context.Context, ip string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s", floatingBasePath, ip)
+
+	req, err := f.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := f.client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/floating_ips_actions.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/floating_ips_actions.go
@@ -1,0 +1,110 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+// FloatingIPActionsService is an interface for interfacing with the
+// floating IPs actions endpoints of the Digital Ocean API.
+// See: https://developers.digitalocean.com/documentation/v2#floating-ips-action
+type FloatingIPActionsService interface {
+	Assign(ctx context.Context, ip string, dropletID int) (*Action, *Response, error)
+	Unassign(ctx context.Context, ip string) (*Action, *Response, error)
+	Get(ctx context.Context, ip string, actionID int) (*Action, *Response, error)
+	List(ctx context.Context, ip string, opt *ListOptions) ([]Action, *Response, error)
+}
+
+// FloatingIPActionsServiceOp handles communication with the floating IPs
+// action related methods of the DigitalOcean API.
+type FloatingIPActionsServiceOp struct {
+	client *Client
+}
+
+// Assign a floating IP to a droplet.
+func (s *FloatingIPActionsServiceOp) Assign(ctx context.Context, ip string, dropletID int) (*Action, *Response, error) {
+	request := &ActionRequest{
+		"type":       "assign",
+		"droplet_id": dropletID,
+	}
+	return s.doAction(ctx, ip, request)
+}
+
+// Unassign a floating IP from the droplet it is currently assigned to.
+func (s *FloatingIPActionsServiceOp) Unassign(ctx context.Context, ip string) (*Action, *Response, error) {
+	request := &ActionRequest{"type": "unassign"}
+	return s.doAction(ctx, ip, request)
+}
+
+// Get an action for a particular floating IP by id.
+func (s *FloatingIPActionsServiceOp) Get(ctx context.Context, ip string, actionID int) (*Action, *Response, error) {
+	path := fmt.Sprintf("%s/%d", floatingIPActionPath(ip), actionID)
+	return s.get(ctx, path)
+}
+
+// List the actions for a particular floating IP.
+func (s *FloatingIPActionsServiceOp) List(ctx context.Context, ip string, opt *ListOptions) ([]Action, *Response, error) {
+	path := floatingIPActionPath(ip)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.list(ctx, path)
+}
+
+func (s *FloatingIPActionsServiceOp) doAction(ctx context.Context, ip string, request *ActionRequest) (*Action, *Response, error) {
+	path := floatingIPActionPath(ip)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+func (s *FloatingIPActionsServiceOp) get(ctx context.Context, path string) (*Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+func (s *FloatingIPActionsServiceOp) list(ctx context.Context, path string) ([]Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Actions, resp, err
+}
+
+func floatingIPActionPath(ip string) string {
+	return fmt.Sprintf("%s/%s/actions", floatingBasePath, ip)
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/godo.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/godo.go
@@ -1,0 +1,400 @@
+package godo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/google/go-querystring/query"
+	headerLink "github.com/tent/http-link-go"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const (
+	libraryVersion = "1.1.0"
+	defaultBaseURL = "https://api.digitalocean.com/"
+	userAgent      = "godo/" + libraryVersion
+	mediaType      = "application/json"
+
+	headerRateLimit     = "RateLimit-Limit"
+	headerRateRemaining = "RateLimit-Remaining"
+	headerRateReset     = "RateLimit-Reset"
+)
+
+// Client manages communication with DigitalOcean V2 API.
+type Client struct {
+	// HTTP client used to communicate with the DO API.
+	client *http.Client
+
+	// Base URL for API requests.
+	BaseURL *url.URL
+
+	// User agent for client
+	UserAgent string
+
+	// Rate contains the current rate limit for the client as determined by the most recent
+	// API call.
+	Rate Rate
+
+	// Services used for communicating with the API
+	Account           AccountService
+	Actions           ActionsService
+	Domains           DomainsService
+	Droplets          DropletsService
+	DropletActions    DropletActionsService
+	Images            ImagesService
+	ImageActions      ImageActionsService
+	Keys              KeysService
+	Regions           RegionsService
+	Sizes             SizesService
+	FloatingIPs       FloatingIPsService
+	FloatingIPActions FloatingIPActionsService
+	Snapshots         SnapshotsService
+	Storage           StorageService
+	StorageActions    StorageActionsService
+	Tags              TagsService
+	LoadBalancers     LoadBalancersService
+	Certificates      CertificatesService
+	Firewalls         FirewallsService
+
+	// Optional function called after every successful request made to the DO APIs
+	onRequestCompleted RequestCompletionCallback
+}
+
+// RequestCompletionCallback defines the type of the request callback function
+type RequestCompletionCallback func(*http.Request, *http.Response)
+
+// ListOptions specifies the optional parameters to various List methods that
+// support pagination.
+type ListOptions struct {
+	// For paginated result sets, page of results to retrieve.
+	Page int `url:"page,omitempty"`
+
+	// For paginated result sets, the number of results to include per page.
+	PerPage int `url:"per_page,omitempty"`
+}
+
+// Response is a DigitalOcean response. This wraps the standard http.Response returned from DigitalOcean.
+type Response struct {
+	*http.Response
+
+	// Links that were returned with the response. These are parsed from
+	// request body and not the header.
+	Links *Links
+
+	// Monitoring URI
+	Monitor string
+
+	Rate
+}
+
+// An ErrorResponse reports the error caused by an API request
+type ErrorResponse struct {
+	// HTTP response that caused this error
+	Response *http.Response
+
+	// Error message
+	Message string `json:"message"`
+
+	// RequestID returned from the API, useful to contact support.
+	RequestID string `json:"request_id"`
+}
+
+// Rate contains the rate limit for the current client.
+type Rate struct {
+	// The number of request per hour the client is currently limited to.
+	Limit int `json:"limit"`
+
+	// The number of remaining requests the client can make this hour.
+	Remaining int `json:"remaining"`
+
+	// The time at which the current rate limit will reset.
+	Reset Timestamp `json:"reset"`
+}
+
+func addOptions(s string, opt interface{}) (string, error) {
+	v := reflect.ValueOf(opt)
+
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return s, nil
+	}
+
+	origURL, err := url.Parse(s)
+	if err != nil {
+		return s, err
+	}
+
+	origValues := origURL.Query()
+
+	newValues, err := query.Values(opt)
+	if err != nil {
+		return s, err
+	}
+
+	for k, v := range newValues {
+		origValues[k] = v
+	}
+
+	origURL.RawQuery = origValues.Encode()
+	return origURL.String(), nil
+}
+
+// NewClient returns a new DigitalOcean API client.
+func NewClient(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	baseURL, _ := url.Parse(defaultBaseURL)
+
+	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
+	c.Account = &AccountServiceOp{client: c}
+	c.Actions = &ActionsServiceOp{client: c}
+	c.Domains = &DomainsServiceOp{client: c}
+	c.Droplets = &DropletsServiceOp{client: c}
+	c.DropletActions = &DropletActionsServiceOp{client: c}
+	c.FloatingIPs = &FloatingIPsServiceOp{client: c}
+	c.FloatingIPActions = &FloatingIPActionsServiceOp{client: c}
+	c.Images = &ImagesServiceOp{client: c}
+	c.ImageActions = &ImageActionsServiceOp{client: c}
+	c.Keys = &KeysServiceOp{client: c}
+	c.Regions = &RegionsServiceOp{client: c}
+	c.Snapshots = &SnapshotsServiceOp{client: c}
+	c.Sizes = &SizesServiceOp{client: c}
+	c.Storage = &StorageServiceOp{client: c}
+	c.StorageActions = &StorageActionsServiceOp{client: c}
+	c.Tags = &TagsServiceOp{client: c}
+	c.LoadBalancers = &LoadBalancersServiceOp{client: c}
+	c.Certificates = &CertificatesServiceOp{client: c}
+	c.Firewalls = &FirewallsServiceOp{client: c}
+
+	return c
+}
+
+// ClientOpt are options for New.
+type ClientOpt func(*Client) error
+
+// New returns a new DIgitalOcean API client instance.
+func New(httpClient *http.Client, opts ...ClientOpt) (*Client, error) {
+	c := NewClient(httpClient)
+	for _, opt := range opts {
+		if err := opt(c); err != nil {
+			return nil, err
+		}
+	}
+
+	return c, nil
+}
+
+// SetBaseURL is a client option for setting the base URL.
+func SetBaseURL(bu string) ClientOpt {
+	return func(c *Client) error {
+		u, err := url.Parse(bu)
+		if err != nil {
+			return err
+		}
+
+		c.BaseURL = u
+		return nil
+	}
+}
+
+// SetUserAgent is a client option for setting the user agent.
+func SetUserAgent(ua string) ClientOpt {
+	return func(c *Client) error {
+		c.UserAgent = fmt.Sprintf("%s %s", ua, c.UserAgent)
+		return nil
+	}
+}
+
+// NewRequest creates an API request. A relative URL can be provided in urlStr, which will be resolved to the
+// BaseURL of the Client. Relative URLS should always be specified without a preceding slash. If specified, the
+// value pointed to by body is JSON encoded and included in as the request body.
+func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
+	rel, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.BaseURL.ResolveReference(rel)
+
+	buf := new(bytes.Buffer)
+	if body != nil {
+		err = json.NewEncoder(buf).Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", mediaType)
+	req.Header.Add("Accept", mediaType)
+	req.Header.Add("User-Agent", c.UserAgent)
+	return req, nil
+}
+
+// OnRequestCompleted sets the DO API request completion callback
+func (c *Client) OnRequestCompleted(rc RequestCompletionCallback) {
+	c.onRequestCompleted = rc
+}
+
+// newResponse creates a new Response for the provided http.Response
+func newResponse(r *http.Response) *Response {
+	response := Response{Response: r}
+	response.populateRate()
+
+	return &response
+}
+
+func (r *Response) links() (map[string]headerLink.Link, error) {
+	if linkText, ok := r.Response.Header["Link"]; ok {
+		links, err := headerLink.Parse(linkText[0])
+
+		if err != nil {
+			return nil, err
+		}
+
+		linkMap := map[string]headerLink.Link{}
+		for _, link := range links {
+			linkMap[link.Rel] = link
+		}
+
+		return linkMap, nil
+	}
+
+	return map[string]headerLink.Link{}, nil
+}
+
+// populateRate parses the rate related headers and populates the response Rate.
+func (r *Response) populateRate() {
+	if limit := r.Header.Get(headerRateLimit); limit != "" {
+		r.Rate.Limit, _ = strconv.Atoi(limit)
+	}
+	if remaining := r.Header.Get(headerRateRemaining); remaining != "" {
+		r.Rate.Remaining, _ = strconv.Atoi(remaining)
+	}
+	if reset := r.Header.Get(headerRateReset); reset != "" {
+		if v, _ := strconv.ParseInt(reset, 10, 64); v != 0 {
+			r.Rate.Reset = Timestamp{time.Unix(v, 0)}
+		}
+	}
+}
+
+// Do sends an API request and returns the API response. The API response is JSON decoded and stored in the value
+// pointed to by v, or returned as an error if an API error has occurred. If v implements the io.Writer interface,
+// the raw response will be written to v, without attempting to decode it.
+func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Response, error) {
+	resp, err := context.DoRequestWithClient(ctx, c.client, req)
+	if err != nil {
+		return nil, err
+	}
+	if c.onRequestCompleted != nil {
+		c.onRequestCompleted(req, resp)
+	}
+
+	defer func() {
+		if rerr := resp.Body.Close(); err == nil {
+			err = rerr
+		}
+	}()
+
+	response := newResponse(resp)
+	c.Rate = response.Rate
+
+	err = CheckResponse(resp)
+	if err != nil {
+		return response, err
+	}
+
+	if v != nil {
+		if w, ok := v.(io.Writer); ok {
+			_, err = io.Copy(w, resp.Body)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			err = json.NewDecoder(resp.Body).Decode(v)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return response, err
+}
+func (r *ErrorResponse) Error() string {
+	if r.RequestID != "" {
+		return fmt.Sprintf("%v %v: %d (request %q) %v",
+			r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.RequestID, r.Message)
+	}
+	return fmt.Sprintf("%v %v: %d %v",
+		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.Message)
+}
+
+// CheckResponse checks the API response for errors, and returns them if present. A response is considered an
+// error if it has a status code outside the 200 range. API error responses are expected to have either no response
+// body, or a JSON response body that maps to ErrorResponse. Any other response body will be silently ignored.
+func CheckResponse(r *http.Response) error {
+	if c := r.StatusCode; c >= 200 && c <= 299 {
+		return nil
+	}
+
+	errorResponse := &ErrorResponse{Response: r}
+	data, err := ioutil.ReadAll(r.Body)
+	if err == nil && len(data) > 0 {
+		err := json.Unmarshal(data, errorResponse)
+		if err != nil {
+			return err
+		}
+	}
+
+	return errorResponse
+}
+
+func (r Rate) String() string {
+	return Stringify(r)
+}
+
+// String is a helper routine that allocates a new string value
+// to store v and returns a pointer to it.
+func String(v string) *string {
+	p := new(string)
+	*p = v
+	return p
+}
+
+// Int is a helper routine that allocates a new int32 value
+// to store v and returns a pointer to it, but unlike Int32
+// its argument value is an int.
+func Int(v int) *int {
+	p := new(int)
+	*p = v
+	return p
+}
+
+// Bool is a helper routine that allocates a new bool value
+// to store v and returns a pointer to it.
+func Bool(v bool) *bool {
+	p := new(bool)
+	*p = v
+	return p
+}
+
+// StreamToString converts a reader to a string
+func StreamToString(stream io.Reader) string {
+	buf := new(bytes.Buffer)
+	_, _ = buf.ReadFrom(stream)
+	return buf.String()
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/image_actions.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/image_actions.go
@@ -1,0 +1,103 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+// ImageActionsService is an interface for interfacing with the image actions
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2#image-actions
+type ImageActionsService interface {
+	Get(context.Context, int, int) (*Action, *Response, error)
+	Transfer(context.Context, int, *ActionRequest) (*Action, *Response, error)
+	Convert(context.Context, int) (*Action, *Response, error)
+}
+
+// ImageActionsServiceOp handles communition with the image action related methods of the
+// DigitalOcean API.
+type ImageActionsServiceOp struct {
+	client *Client
+}
+
+var _ ImageActionsService = &ImageActionsServiceOp{}
+
+// Transfer an image
+func (i *ImageActionsServiceOp) Transfer(ctx context.Context, imageID int, transferRequest *ActionRequest) (*Action, *Response, error) {
+	if imageID < 1 {
+		return nil, nil, NewArgError("imageID", "cannot be less than 1")
+	}
+
+	if transferRequest == nil {
+		return nil, nil, NewArgError("transferRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("v2/images/%d/actions", imageID)
+
+	req, err := i.client.NewRequest(ctx, http.MethodPost, path, transferRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := i.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+// Convert an image to a snapshot
+func (i *ImageActionsServiceOp) Convert(ctx context.Context, imageID int) (*Action, *Response, error) {
+	if imageID < 1 {
+		return nil, nil, NewArgError("imageID", "cannont be less than 1")
+	}
+
+	path := fmt.Sprintf("v2/images/%d/actions", imageID)
+
+	convertRequest := &ActionRequest{
+		"type": "convert",
+	}
+
+	req, err := i.client.NewRequest(ctx, http.MethodPost, path, convertRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := i.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+// Get an action for a particular image by id.
+func (i *ImageActionsServiceOp) Get(ctx context.Context, imageID, actionID int) (*Action, *Response, error) {
+	if imageID < 1 {
+		return nil, nil, NewArgError("imageID", "cannot be less than 1")
+	}
+
+	if actionID < 1 {
+		return nil, nil, NewArgError("actionID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("v2/images/%d/actions/%d", imageID, actionID)
+
+	req, err := i.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := i.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/images.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/images.go
@@ -1,0 +1,199 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const imageBasePath = "v2/images"
+
+// ImagesService is an interface for interfacing with the images
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2#images
+type ImagesService interface {
+	List(context.Context, *ListOptions) ([]Image, *Response, error)
+	ListDistribution(ctx context.Context, opt *ListOptions) ([]Image, *Response, error)
+	ListApplication(ctx context.Context, opt *ListOptions) ([]Image, *Response, error)
+	ListUser(ctx context.Context, opt *ListOptions) ([]Image, *Response, error)
+	GetByID(context.Context, int) (*Image, *Response, error)
+	GetBySlug(context.Context, string) (*Image, *Response, error)
+	Update(context.Context, int, *ImageUpdateRequest) (*Image, *Response, error)
+	Delete(context.Context, int) (*Response, error)
+}
+
+// ImagesServiceOp handles communication with the image related methods of the
+// DigitalOcean API.
+type ImagesServiceOp struct {
+	client *Client
+}
+
+var _ ImagesService = &ImagesServiceOp{}
+
+// Image represents a DigitalOcean Image
+type Image struct {
+	ID           int      `json:"id,float64,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Type         string   `json:"type,omitempty"`
+	Distribution string   `json:"distribution,omitempty"`
+	Slug         string   `json:"slug,omitempty"`
+	Public       bool     `json:"public,omitempty"`
+	Regions      []string `json:"regions,omitempty"`
+	MinDiskSize  int      `json:"min_disk_size,omitempty"`
+	Created      string   `json:"created_at,omitempty"`
+}
+
+// ImageUpdateRequest represents a request to update an image.
+type ImageUpdateRequest struct {
+	Name string `json:"name"`
+}
+
+type imageRoot struct {
+	Image *Image
+}
+
+type imagesRoot struct {
+	Images []Image
+	Links  *Links `json:"links"`
+}
+
+type listImageOptions struct {
+	Private bool   `url:"private,omitempty"`
+	Type    string `url:"type,omitempty"`
+}
+
+func (i Image) String() string {
+	return Stringify(i)
+}
+
+// List lists all the images available.
+func (s *ImagesServiceOp) List(ctx context.Context, opt *ListOptions) ([]Image, *Response, error) {
+	return s.list(ctx, opt, nil)
+}
+
+// ListDistribution lists all the distribution images.
+func (s *ImagesServiceOp) ListDistribution(ctx context.Context, opt *ListOptions) ([]Image, *Response, error) {
+	listOpt := listImageOptions{Type: "distribution"}
+	return s.list(ctx, opt, &listOpt)
+}
+
+// ListApplication lists all the application images.
+func (s *ImagesServiceOp) ListApplication(ctx context.Context, opt *ListOptions) ([]Image, *Response, error) {
+	listOpt := listImageOptions{Type: "application"}
+	return s.list(ctx, opt, &listOpt)
+}
+
+// ListUser lists all the user images.
+func (s *ImagesServiceOp) ListUser(ctx context.Context, opt *ListOptions) ([]Image, *Response, error) {
+	listOpt := listImageOptions{Private: true}
+	return s.list(ctx, opt, &listOpt)
+}
+
+// GetByID retrieves an image by id.
+func (s *ImagesServiceOp) GetByID(ctx context.Context, imageID int) (*Image, *Response, error) {
+	if imageID < 1 {
+		return nil, nil, NewArgError("imageID", "cannot be less than 1")
+	}
+
+	return s.get(ctx, interface{}(imageID))
+}
+
+// GetBySlug retrieves an image by slug.
+func (s *ImagesServiceOp) GetBySlug(ctx context.Context, slug string) (*Image, *Response, error) {
+	if len(slug) < 1 {
+		return nil, nil, NewArgError("slug", "cannot be blank")
+	}
+
+	return s.get(ctx, interface{}(slug))
+}
+
+// Update an image name.
+func (s *ImagesServiceOp) Update(ctx context.Context, imageID int, updateRequest *ImageUpdateRequest) (*Image, *Response, error) {
+	if imageID < 1 {
+		return nil, nil, NewArgError("imageID", "cannot be less than 1")
+	}
+
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("%s/%d", imageBasePath, imageID)
+	req, err := s.client.NewRequest(ctx, "PUT", path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(imageRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Image, resp, err
+}
+
+// Delete an image.
+func (s *ImagesServiceOp) Delete(ctx context.Context, imageID int) (*Response, error) {
+	if imageID < 1 {
+		return nil, NewArgError("imageID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d", imageBasePath, imageID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// Helper method for getting an individual image
+func (s *ImagesServiceOp) get(ctx context.Context, ID interface{}) (*Image, *Response, error) {
+	path := fmt.Sprintf("%s/%v", imageBasePath, ID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(imageRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Image, resp, err
+}
+
+// Helper method for listing images
+func (s *ImagesServiceOp) list(ctx context.Context, opt *ListOptions, listOpt *listImageOptions) ([]Image, *Response, error) {
+	path := imageBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	path, err = addOptions(path, listOpt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(imagesRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Images, resp, err
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/keys.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/keys.go
@@ -1,0 +1,227 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const keysBasePath = "v2/account/keys"
+
+// KeysService is an interface for interfacing with the keys
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2#keys
+type KeysService interface {
+	List(context.Context, *ListOptions) ([]Key, *Response, error)
+	GetByID(context.Context, int) (*Key, *Response, error)
+	GetByFingerprint(context.Context, string) (*Key, *Response, error)
+	Create(context.Context, *KeyCreateRequest) (*Key, *Response, error)
+	UpdateByID(context.Context, int, *KeyUpdateRequest) (*Key, *Response, error)
+	UpdateByFingerprint(context.Context, string, *KeyUpdateRequest) (*Key, *Response, error)
+	DeleteByID(context.Context, int) (*Response, error)
+	DeleteByFingerprint(context.Context, string) (*Response, error)
+}
+
+// KeysServiceOp handles communication with key related method of the
+// DigitalOcean API.
+type KeysServiceOp struct {
+	client *Client
+}
+
+var _ KeysService = &KeysServiceOp{}
+
+// Key represents a DigitalOcean Key.
+type Key struct {
+	ID          int    `json:"id,float64,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Fingerprint string `json:"fingerprint,omitempty"`
+	PublicKey   string `json:"public_key,omitempty"`
+}
+
+// KeyUpdateRequest represents a request to update a DigitalOcean key.
+type KeyUpdateRequest struct {
+	Name string `json:"name"`
+}
+
+type keysRoot struct {
+	SSHKeys []Key  `json:"ssh_keys"`
+	Links   *Links `json:"links"`
+}
+
+type keyRoot struct {
+	SSHKey *Key `json:"ssh_key"`
+}
+
+func (s Key) String() string {
+	return Stringify(s)
+}
+
+// KeyCreateRequest represents a request to create a new key.
+type KeyCreateRequest struct {
+	Name      string `json:"name"`
+	PublicKey string `json:"public_key"`
+}
+
+// List all keys
+func (s *KeysServiceOp) List(ctx context.Context, opt *ListOptions) ([]Key, *Response, error) {
+	path := keysBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(keysRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.SSHKeys, resp, err
+}
+
+// Performs a get given a path
+func (s *KeysServiceOp) get(ctx context.Context, path string) (*Key, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(keyRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.SSHKey, resp, err
+}
+
+// GetByID gets a Key by id
+func (s *KeysServiceOp) GetByID(ctx context.Context, keyID int) (*Key, *Response, error) {
+	if keyID < 1 {
+		return nil, nil, NewArgError("keyID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d", keysBasePath, keyID)
+	return s.get(ctx, path)
+}
+
+// GetByFingerprint gets a Key by by fingerprint
+func (s *KeysServiceOp) GetByFingerprint(ctx context.Context, fingerprint string) (*Key, *Response, error) {
+	if len(fingerprint) < 1 {
+		return nil, nil, NewArgError("fingerprint", "cannot not be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", keysBasePath, fingerprint)
+	return s.get(ctx, path)
+}
+
+// Create a key using a KeyCreateRequest
+func (s *KeysServiceOp) Create(ctx context.Context, createRequest *KeyCreateRequest) (*Key, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, keysBasePath, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(keyRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.SSHKey, resp, err
+}
+
+// UpdateByID updates a key name by ID.
+func (s *KeysServiceOp) UpdateByID(ctx context.Context, keyID int, updateRequest *KeyUpdateRequest) (*Key, *Response, error) {
+	if keyID < 1 {
+		return nil, nil, NewArgError("keyID", "cannot be less than 1")
+	}
+
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("%s/%d", keysBasePath, keyID)
+	req, err := s.client.NewRequest(ctx, "PUT", path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(keyRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.SSHKey, resp, err
+}
+
+// UpdateByFingerprint updates a key name by fingerprint.
+func (s *KeysServiceOp) UpdateByFingerprint(ctx context.Context, fingerprint string, updateRequest *KeyUpdateRequest) (*Key, *Response, error) {
+	if len(fingerprint) < 1 {
+		return nil, nil, NewArgError("fingerprint", "cannot be empty")
+	}
+
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("%s/%s", keysBasePath, fingerprint)
+	req, err := s.client.NewRequest(ctx, "PUT", path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(keyRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.SSHKey, resp, err
+}
+
+// Delete key using a path
+func (s *KeysServiceOp) delete(ctx context.Context, path string) (*Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// DeleteByID deletes a key by its id
+func (s *KeysServiceOp) DeleteByID(ctx context.Context, keyID int) (*Response, error) {
+	if keyID < 1 {
+		return nil, NewArgError("keyID", "cannot be less than 1")
+	}
+
+	path := fmt.Sprintf("%s/%d", keysBasePath, keyID)
+	return s.delete(ctx, path)
+}
+
+// DeleteByFingerprint deletes a key by its fingerprint
+func (s *KeysServiceOp) DeleteByFingerprint(ctx context.Context, fingerprint string) (*Response, error) {
+	if len(fingerprint) < 1 {
+		return nil, NewArgError("fingerprint", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", keysBasePath, fingerprint)
+	return s.delete(ctx, path)
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/links.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/links.go
@@ -1,0 +1,84 @@
+package godo
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/digitalocean/godo/context"
+)
+
+// Links manages links that are returned along with a List
+type Links struct {
+	Pages   *Pages       `json:"pages,omitempty"`
+	Actions []LinkAction `json:"actions,omitempty"`
+}
+
+// Pages are pages specified in Links
+type Pages struct {
+	First string `json:"first,omitempty"`
+	Prev  string `json:"prev,omitempty"`
+	Last  string `json:"last,omitempty"`
+	Next  string `json:"next,omitempty"`
+}
+
+// LinkAction is a pointer to an action
+type LinkAction struct {
+	ID   int    `json:"id,omitempty"`
+	Rel  string `json:"rel,omitempty"`
+	HREF string `json:"href,omitempty"`
+}
+
+// CurrentPage is current page of the list
+func (l *Links) CurrentPage() (int, error) {
+	return l.Pages.current()
+}
+
+func (p *Pages) current() (int, error) {
+	switch {
+	case p == nil:
+		return 1, nil
+	case p.Prev == "" && p.Next != "":
+		return 1, nil
+	case p.Prev != "":
+		prevPage, err := pageForURL(p.Prev)
+		if err != nil {
+			return 0, err
+		}
+
+		return prevPage + 1, nil
+	}
+
+	return 0, nil
+}
+
+// IsLastPage returns true if the current page is the last
+func (l *Links) IsLastPage() bool {
+	if l.Pages == nil {
+		return true
+	}
+	return l.Pages.isLast()
+}
+
+func (p *Pages) isLast() bool {
+	return p.Last == ""
+}
+
+func pageForURL(urlText string) (int, error) {
+	u, err := url.ParseRequestURI(urlText)
+	if err != nil {
+		return 0, err
+	}
+
+	pageStr := u.Query().Get("page")
+	page, err := strconv.Atoi(pageStr)
+	if err != nil {
+		return 0, err
+	}
+
+	return page, nil
+}
+
+// Get a link action by id.
+func (la *LinkAction) Get(ctx context.Context, client *Client) (*Action, *Response, error) {
+	return client.Actions.Get(ctx, la.ID)
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -1,0 +1,304 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const loadBalancersBasePath = "/v2/load_balancers"
+const forwardingRulesPath = "forwarding_rules"
+
+const dropletsPath = "droplets"
+
+// LoadBalancersService is an interface for managing load balancers with the DigitalOcean API.
+// See: https://developers.digitalocean.com/documentation/v2#load-balancers
+type LoadBalancersService interface {
+	Get(context.Context, string) (*LoadBalancer, *Response, error)
+	List(context.Context, *ListOptions) ([]LoadBalancer, *Response, error)
+	Create(context.Context, *LoadBalancerRequest) (*LoadBalancer, *Response, error)
+	Update(ctx context.Context, lbID string, lbr *LoadBalancerRequest) (*LoadBalancer, *Response, error)
+	Delete(ctx context.Context, lbID string) (*Response, error)
+	AddDroplets(ctx context.Context, lbID string, dropletIDs ...int) (*Response, error)
+	RemoveDroplets(ctx context.Context, lbID string, dropletIDs ...int) (*Response, error)
+	AddForwardingRules(ctx context.Context, lbID string, rules ...ForwardingRule) (*Response, error)
+	RemoveForwardingRules(ctx context.Context, lbID string, rules ...ForwardingRule) (*Response, error)
+}
+
+// LoadBalancer represents a DigitalOcean load balancer configuration.
+type LoadBalancer struct {
+	ID                  string           `json:"id,omitempty"`
+	Name                string           `json:"name,omitempty"`
+	IP                  string           `json:"ip,omitempty"`
+	Algorithm           string           `json:"algorithm,omitempty"`
+	Status              string           `json:"status,omitempty"`
+	Created             string           `json:"created_at,omitempty"`
+	ForwardingRules     []ForwardingRule `json:"forwarding_rules,omitempty"`
+	HealthCheck         *HealthCheck     `json:"health_check,omitempty"`
+	StickySessions      *StickySessions  `json:"sticky_sessions,omitempty"`
+	Region              *Region          `json:"region,omitempty"`
+	DropletIDs          []int            `json:"droplet_ids,omitempty"`
+	Tag                 string           `json:"tag,omitempty"`
+	RedirectHttpToHttps bool             `json:"redirect_http_to_https,omitempty"`
+}
+
+// String creates a human-readable description of a LoadBalancer.
+func (l LoadBalancer) String() string {
+	return Stringify(l)
+}
+
+// AsRequest creates a LoadBalancerRequest that can be submitted to Update with the current values of the LoadBalancer.
+// Modifying the returned LoadBalancerRequest will not modify the original LoadBalancer.
+func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
+	r := LoadBalancerRequest{
+		Name:                l.Name,
+		Algorithm:           l.Algorithm,
+		ForwardingRules:     append([]ForwardingRule(nil), l.ForwardingRules...),
+		DropletIDs:          append([]int(nil), l.DropletIDs...),
+		Tag:                 l.Tag,
+		RedirectHttpToHttps: l.RedirectHttpToHttps,
+		HealthCheck:         l.HealthCheck,
+	}
+	if l.HealthCheck != nil {
+		r.HealthCheck = &HealthCheck{}
+		*r.HealthCheck = *l.HealthCheck
+	}
+	if l.StickySessions != nil {
+		r.StickySessions = &StickySessions{}
+		*r.StickySessions = *l.StickySessions
+	}
+	if l.Region != nil {
+		r.Region = l.Region.Slug
+	}
+	return &r
+}
+
+// ForwardingRule represents load balancer forwarding rules.
+type ForwardingRule struct {
+	EntryProtocol  string `json:"entry_protocol,omitempty"`
+	EntryPort      int    `json:"entry_port,omitempty"`
+	TargetProtocol string `json:"target_protocol,omitempty"`
+	TargetPort     int    `json:"target_port,omitempty"`
+	CertificateID  string `json:"certificate_id,omitempty"`
+	TlsPassthrough bool   `json:"tls_passthrough,omitempty"`
+}
+
+// String creates a human-readable description of a ForwardingRule.
+func (f ForwardingRule) String() string {
+	return Stringify(f)
+}
+
+// HealthCheck represents optional load balancer health check rules.
+type HealthCheck struct {
+	Protocol               string `json:"protocol,omitempty"`
+	Port                   int    `json:"port,omitempty"`
+	Path                   string `json:"path,omitempty"`
+	CheckIntervalSeconds   int    `json:"check_interval_seconds,omitempty"`
+	ResponseTimeoutSeconds int    `json:"response_timeout_seconds,omitempty"`
+	HealthyThreshold       int    `json:"healthy_threshold,omitempty"`
+	UnhealthyThreshold     int    `json:"unhealthy_threshold,omitempty"`
+}
+
+// String creates a human-readable description of a HealthCheck.
+func (h HealthCheck) String() string {
+	return Stringify(h)
+}
+
+// StickySessions represents optional load balancer session affinity rules.
+type StickySessions struct {
+	Type             string `json:"type,omitempty"`
+	CookieName       string `json:"cookie_name,omitempty"`
+	CookieTtlSeconds int    `json:"cookie_ttl_seconds,omitempty"`
+}
+
+// String creates a human-readable description of a StickySessions instance.
+func (s StickySessions) String() string {
+	return Stringify(s)
+}
+
+// LoadBalancerRequest represents the configuration to be applied to an existing or a new load balancer.
+type LoadBalancerRequest struct {
+	Name                string           `json:"name,omitempty"`
+	Algorithm           string           `json:"algorithm,omitempty"`
+	Region              string           `json:"region,omitempty"`
+	ForwardingRules     []ForwardingRule `json:"forwarding_rules,omitempty"`
+	HealthCheck         *HealthCheck     `json:"health_check,omitempty"`
+	StickySessions      *StickySessions  `json:"sticky_sessions,omitempty"`
+	DropletIDs          []int            `json:"droplet_ids,omitempty"`
+	Tag                 string           `json:"tag,omitempty"`
+	RedirectHttpToHttps bool             `json:"redirect_http_to_https,omitempty"`
+}
+
+// String creates a human-readable description of a LoadBalancerRequest.
+func (l LoadBalancerRequest) String() string {
+	return Stringify(l)
+}
+
+type forwardingRulesRequest struct {
+	Rules []ForwardingRule `json:"forwarding_rules,omitempty"`
+}
+
+func (l forwardingRulesRequest) String() string {
+	return Stringify(l)
+}
+
+type dropletIDsRequest struct {
+	IDs []int `json:"droplet_ids,omitempty"`
+}
+
+func (l dropletIDsRequest) String() string {
+	return Stringify(l)
+}
+
+type loadBalancersRoot struct {
+	LoadBalancers []LoadBalancer `json:"load_balancers"`
+	Links         *Links         `json:"links"`
+}
+
+type loadBalancerRoot struct {
+	LoadBalancer *LoadBalancer `json:"load_balancer"`
+}
+
+// LoadBalancersServiceOp handles communication with load balancer-related methods of the DigitalOcean API.
+type LoadBalancersServiceOp struct {
+	client *Client
+}
+
+var _ LoadBalancersService = &LoadBalancersServiceOp{}
+
+// Get an existing load balancer by its identifier.
+func (l *LoadBalancersServiceOp) Get(ctx context.Context, lbID string) (*LoadBalancer, *Response, error) {
+	path := fmt.Sprintf("%s/%s", loadBalancersBasePath, lbID)
+
+	req, err := l.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(loadBalancerRoot)
+	resp, err := l.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.LoadBalancer, resp, err
+}
+
+// List load balancers, with optional pagination.
+func (l *LoadBalancersServiceOp) List(ctx context.Context, opt *ListOptions) ([]LoadBalancer, *Response, error) {
+	path, err := addOptions(loadBalancersBasePath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := l.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(loadBalancersRoot)
+	resp, err := l.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.LoadBalancers, resp, err
+}
+
+// Create a new load balancer with a given configuration.
+func (l *LoadBalancersServiceOp) Create(ctx context.Context, lbr *LoadBalancerRequest) (*LoadBalancer, *Response, error) {
+	req, err := l.client.NewRequest(ctx, http.MethodPost, loadBalancersBasePath, lbr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(loadBalancerRoot)
+	resp, err := l.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.LoadBalancer, resp, err
+}
+
+// Update an existing load balancer with new configuration.
+func (l *LoadBalancersServiceOp) Update(ctx context.Context, lbID string, lbr *LoadBalancerRequest) (*LoadBalancer, *Response, error) {
+	path := fmt.Sprintf("%s/%s", loadBalancersBasePath, lbID)
+
+	req, err := l.client.NewRequest(ctx, "PUT", path, lbr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(loadBalancerRoot)
+	resp, err := l.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.LoadBalancer, resp, err
+}
+
+// Delete a load balancer by its identifier.
+func (l *LoadBalancersServiceOp) Delete(ctx context.Context, ldID string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s", loadBalancersBasePath, ldID)
+
+	req, err := l.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return l.client.Do(ctx, req, nil)
+}
+
+// AddDroplets adds droplets to a load balancer.
+func (l *LoadBalancersServiceOp) AddDroplets(ctx context.Context, lbID string, dropletIDs ...int) (*Response, error) {
+	path := fmt.Sprintf("%s/%s/%s", loadBalancersBasePath, lbID, dropletsPath)
+
+	req, err := l.client.NewRequest(ctx, http.MethodPost, path, &dropletIDsRequest{IDs: dropletIDs})
+	if err != nil {
+		return nil, err
+	}
+
+	return l.client.Do(ctx, req, nil)
+}
+
+// RemoveDroplets removes droplets from a load balancer.
+func (l *LoadBalancersServiceOp) RemoveDroplets(ctx context.Context, lbID string, dropletIDs ...int) (*Response, error) {
+	path := fmt.Sprintf("%s/%s/%s", loadBalancersBasePath, lbID, dropletsPath)
+
+	req, err := l.client.NewRequest(ctx, http.MethodDelete, path, &dropletIDsRequest{IDs: dropletIDs})
+	if err != nil {
+		return nil, err
+	}
+
+	return l.client.Do(ctx, req, nil)
+}
+
+// AddForwardingRules adds forwarding rules to a load balancer.
+func (l *LoadBalancersServiceOp) AddForwardingRules(ctx context.Context, lbID string, rules ...ForwardingRule) (*Response, error) {
+	path := fmt.Sprintf("%s/%s/%s", loadBalancersBasePath, lbID, forwardingRulesPath)
+
+	req, err := l.client.NewRequest(ctx, http.MethodPost, path, &forwardingRulesRequest{Rules: rules})
+	if err != nil {
+		return nil, err
+	}
+
+	return l.client.Do(ctx, req, nil)
+}
+
+// RemoveForwardingRules removes forwarding rules from a load balancer.
+func (l *LoadBalancersServiceOp) RemoveForwardingRules(ctx context.Context, lbID string, rules ...ForwardingRule) (*Response, error) {
+	path := fmt.Sprintf("%s/%s/%s", loadBalancersBasePath, lbID, forwardingRulesPath)
+
+	req, err := l.client.NewRequest(ctx, http.MethodDelete, path, &forwardingRulesRequest{Rules: rules})
+	if err != nil {
+		return nil, err
+	}
+
+	return l.client.Do(ctx, req, nil)
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/regions.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/regions.go
@@ -1,0 +1,65 @@
+package godo
+
+import (
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+// RegionsService is an interface for interfacing with the regions
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2#regions
+type RegionsService interface {
+	List(context.Context, *ListOptions) ([]Region, *Response, error)
+}
+
+// RegionsServiceOp handles communication with the region related methods of the
+// DigitalOcean API.
+type RegionsServiceOp struct {
+	client *Client
+}
+
+var _ RegionsService = &RegionsServiceOp{}
+
+// Region represents a DigitalOcean Region
+type Region struct {
+	Slug      string   `json:"slug,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	Sizes     []string `json:"sizes,omitempty"`
+	Available bool     `json:"available,omitempty"`
+	Features  []string `json:"features,omitempty"`
+}
+
+type regionsRoot struct {
+	Regions []Region
+	Links   *Links `json:"links"`
+}
+
+func (r Region) String() string {
+	return Stringify(r)
+}
+
+// List all regions
+func (s *RegionsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Region, *Response, error) {
+	path := "v2/regions"
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(regionsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Regions, resp, err
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/sizes.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/sizes.go
@@ -1,0 +1,69 @@
+package godo
+
+import (
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+// SizesService is an interface for interfacing with the size
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2#sizes
+type SizesService interface {
+	List(context.Context, *ListOptions) ([]Size, *Response, error)
+}
+
+// SizesServiceOp handles communication with the size related methods of the
+// DigitalOcean API.
+type SizesServiceOp struct {
+	client *Client
+}
+
+var _ SizesService = &SizesServiceOp{}
+
+// Size represents a DigitalOcean Size
+type Size struct {
+	Slug         string   `json:"slug,omitempty"`
+	Memory       int      `json:"memory,omitempty"`
+	Vcpus        int      `json:"vcpus,omitempty"`
+	Disk         int      `json:"disk,omitempty"`
+	PriceMonthly float64  `json:"price_monthly,omitempty"`
+	PriceHourly  float64  `json:"price_hourly,omitempty"`
+	Regions      []string `json:"regions,omitempty"`
+	Available    bool     `json:"available,omitempty"`
+	Transfer     float64  `json:"transfer,omitempty"`
+}
+
+func (s Size) String() string {
+	return Stringify(s)
+}
+
+type sizesRoot struct {
+	Sizes []Size
+	Links *Links `json:"links"`
+}
+
+// List all images
+func (s *SizesServiceOp) List(ctx context.Context, opt *ListOptions) ([]Size, *Response, error) {
+	path := "v2/sizes"
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(sizesRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Sizes, resp, err
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/snapshots.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/snapshots.go
@@ -1,0 +1,141 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const snapshotBasePath = "v2/snapshots"
+
+// SnapshotsService is an interface for interfacing with the snapshots
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2#snapshots
+type SnapshotsService interface {
+	List(context.Context, *ListOptions) ([]Snapshot, *Response, error)
+	ListVolume(context.Context, *ListOptions) ([]Snapshot, *Response, error)
+	ListDroplet(context.Context, *ListOptions) ([]Snapshot, *Response, error)
+	Get(context.Context, string) (*Snapshot, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+}
+
+// SnapshotsServiceOp handles communication with the snapshot related methods of the
+// DigitalOcean API.
+type SnapshotsServiceOp struct {
+	client *Client
+}
+
+var _ SnapshotsService = &SnapshotsServiceOp{}
+
+// Snapshot represents a DigitalOcean Snapshot
+type Snapshot struct {
+	ID            string   `json:"id,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	ResourceID    string   `json:"resource_id,omitempty"`
+	ResourceType  string   `json:"resource_type,omitempty"`
+	Regions       []string `json:"regions,omitempty"`
+	MinDiskSize   int      `json:"min_disk_size,omitempty"`
+	SizeGigaBytes float64  `json:"size_gigabytes,omitempty"`
+	Created       string   `json:"created_at,omitempty"`
+}
+
+type snapshotRoot struct {
+	Snapshot *Snapshot `json:"snapshot"`
+}
+
+type snapshotsRoot struct {
+	Snapshots []Snapshot `json:"snapshots"`
+	Links     *Links     `json:"links,omitempty"`
+}
+
+type listSnapshotOptions struct {
+	ResourceType string `url:"resource_type,omitempty"`
+}
+
+func (s Snapshot) String() string {
+	return Stringify(s)
+}
+
+// List lists all the snapshots available.
+func (s *SnapshotsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Snapshot, *Response, error) {
+	return s.list(ctx, opt, nil)
+}
+
+// ListDroplet lists all the Droplet snapshots.
+func (s *SnapshotsServiceOp) ListDroplet(ctx context.Context, opt *ListOptions) ([]Snapshot, *Response, error) {
+	listOpt := listSnapshotOptions{ResourceType: "droplet"}
+	return s.list(ctx, opt, &listOpt)
+}
+
+// ListVolume lists all the volume snapshots.
+func (s *SnapshotsServiceOp) ListVolume(ctx context.Context, opt *ListOptions) ([]Snapshot, *Response, error) {
+	listOpt := listSnapshotOptions{ResourceType: "volume"}
+	return s.list(ctx, opt, &listOpt)
+}
+
+// Get retrieves an snapshot by id.
+func (s *SnapshotsServiceOp) Get(ctx context.Context, snapshotID string) (*Snapshot, *Response, error) {
+	return s.get(ctx, snapshotID)
+}
+
+// Delete an snapshot.
+func (s *SnapshotsServiceOp) Delete(ctx context.Context, snapshotID string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s", snapshotBasePath, snapshotID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// Helper method for getting an individual snapshot
+func (s *SnapshotsServiceOp) get(ctx context.Context, ID string) (*Snapshot, *Response, error) {
+	path := fmt.Sprintf("%s/%s", snapshotBasePath, ID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(snapshotRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Snapshot, resp, err
+}
+
+// Helper method for listing snapshots
+func (s *SnapshotsServiceOp) list(ctx context.Context, opt *ListOptions, listOpt *listSnapshotOptions) ([]Snapshot, *Response, error) {
+	path := snapshotBasePath
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	path, err = addOptions(path, listOpt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(snapshotsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Snapshots, resp, err
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/storage.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/storage.go
@@ -1,0 +1,241 @@
+package godo
+
+import (
+	"fmt"
+	"time"
+
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const (
+	storageBasePath  = "v2"
+	storageAllocPath = storageBasePath + "/volumes"
+	storageSnapPath  = storageBasePath + "/snapshots"
+)
+
+// StorageService is an interface for interfacing with the storage
+// endpoints of the Digital Ocean API.
+// See: https://developers.digitalocean.com/documentation/v2#storage
+type StorageService interface {
+	ListVolumes(context.Context, *ListVolumeParams) ([]Volume, *Response, error)
+	GetVolume(context.Context, string) (*Volume, *Response, error)
+	CreateVolume(context.Context, *VolumeCreateRequest) (*Volume, *Response, error)
+	DeleteVolume(context.Context, string) (*Response, error)
+	ListSnapshots(ctx context.Context, volumeID string, opts *ListOptions) ([]Snapshot, *Response, error)
+	GetSnapshot(context.Context, string) (*Snapshot, *Response, error)
+	CreateSnapshot(context.Context, *SnapshotCreateRequest) (*Snapshot, *Response, error)
+	DeleteSnapshot(context.Context, string) (*Response, error)
+}
+
+// StorageServiceOp handles communication with the storage volumes related methods of the
+// DigitalOcean API.
+type StorageServiceOp struct {
+	client *Client
+}
+
+// ListVolumeParams stores the options you can set for a ListVolumeCall
+type ListVolumeParams struct {
+	Region      string       `json:"region"`
+	Name        string       `json:"name"`
+	ListOptions *ListOptions `json:"list_options,omitempty"`
+}
+
+var _ StorageService = &StorageServiceOp{}
+
+// Volume represents a Digital Ocean block store volume.
+type Volume struct {
+	ID            string    `json:"id"`
+	Region        *Region   `json:"region"`
+	Name          string    `json:"name"`
+	SizeGigaBytes int64     `json:"size_gigabytes"`
+	Description   string    `json:"description"`
+	DropletIDs    []int     `json:"droplet_ids"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+func (f Volume) String() string {
+	return Stringify(f)
+}
+
+type storageVolumesRoot struct {
+	Volumes []Volume `json:"volumes"`
+	Links   *Links   `json:"links"`
+}
+
+type storageVolumeRoot struct {
+	Volume *Volume `json:"volume"`
+	Links  *Links  `json:"links,omitempty"`
+}
+
+// VolumeCreateRequest represents a request to create a block store
+// volume.
+type VolumeCreateRequest struct {
+	Region        string `json:"region"`
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	SizeGigaBytes int64  `json:"size_gigabytes"`
+	SnapshotID    string `json:"snapshot_id"`
+}
+
+// ListVolumes lists all storage volumes.
+func (svc *StorageServiceOp) ListVolumes(ctx context.Context, params *ListVolumeParams) ([]Volume, *Response, error) {
+	path := storageAllocPath
+	if params != nil {
+		if params.Region != "" && params.Name != "" {
+			path = fmt.Sprintf("%s?name=%s&region=%s", path, params.Name, params.Region)
+		}
+
+		if params.ListOptions != nil {
+			var err error
+			path, err = addOptions(path, params.ListOptions)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(storageVolumesRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Volumes, resp, nil
+}
+
+// CreateVolume creates a storage volume. The name must be unique.
+func (svc *StorageServiceOp) CreateVolume(ctx context.Context, createRequest *VolumeCreateRequest) (*Volume, *Response, error) {
+	path := storageAllocPath
+
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(storageVolumeRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Volume, resp, nil
+}
+
+// GetVolume retrieves an individual storage volume.
+func (svc *StorageServiceOp) GetVolume(ctx context.Context, id string) (*Volume, *Response, error) {
+	path := fmt.Sprintf("%s/%s", storageAllocPath, id)
+
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(storageVolumeRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Volume, resp, nil
+}
+
+// DeleteVolume deletes a storage volume.
+func (svc *StorageServiceOp) DeleteVolume(ctx context.Context, id string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s", storageAllocPath, id)
+
+	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return svc.client.Do(ctx, req, nil)
+}
+
+// SnapshotCreateRequest represents a request to create a block store
+// volume.
+type SnapshotCreateRequest struct {
+	VolumeID    string `json:"volume_id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// ListSnapshots lists all snapshots related to a storage volume.
+func (svc *StorageServiceOp) ListSnapshots(ctx context.Context, volumeID string, opt *ListOptions) ([]Snapshot, *Response, error) {
+	path := fmt.Sprintf("%s/%s/snapshots", storageAllocPath, volumeID)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(snapshotsRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Snapshots, resp, nil
+}
+
+// CreateSnapshot creates a snapshot of a storage volume.
+func (svc *StorageServiceOp) CreateSnapshot(ctx context.Context, createRequest *SnapshotCreateRequest) (*Snapshot, *Response, error) {
+	path := fmt.Sprintf("%s/%s/snapshots", storageAllocPath, createRequest.VolumeID)
+
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(snapshotRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Snapshot, resp, nil
+}
+
+// GetSnapshot retrieves an individual snapshot.
+func (svc *StorageServiceOp) GetSnapshot(ctx context.Context, id string) (*Snapshot, *Response, error) {
+	path := fmt.Sprintf("%s/%s", storageSnapPath, id)
+
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(snapshotRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Snapshot, resp, nil
+}
+
+// DeleteSnapshot deletes a snapshot.
+func (svc *StorageServiceOp) DeleteSnapshot(ctx context.Context, id string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s", storageSnapPath, id)
+
+	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return svc.client.Do(ctx, req, nil)
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/storage_actions.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/storage_actions.go
@@ -1,0 +1,130 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+// StorageActionsService is an interface for interfacing with the
+// storage actions endpoints of the Digital Ocean API.
+// See: https://developers.digitalocean.com/documentation/v2#storage-actions
+type StorageActionsService interface {
+	Attach(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
+	DetachByDropletID(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error)
+	Get(ctx context.Context, volumeID string, actionID int) (*Action, *Response, error)
+	List(ctx context.Context, volumeID string, opt *ListOptions) ([]Action, *Response, error)
+	Resize(ctx context.Context, volumeID string, sizeGigabytes int, regionSlug string) (*Action, *Response, error)
+}
+
+// StorageActionsServiceOp handles communication with the storage volumes
+// action related methods of the DigitalOcean API.
+type StorageActionsServiceOp struct {
+	client *Client
+}
+
+// StorageAttachment represents the attachement of a block storage
+// volume to a specific Droplet under the device name.
+type StorageAttachment struct {
+	DropletID int `json:"droplet_id"`
+}
+
+// Attach a storage volume to a Droplet.
+func (s *StorageActionsServiceOp) Attach(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error) {
+	request := &ActionRequest{
+		"type":       "attach",
+		"droplet_id": dropletID,
+	}
+	return s.doAction(ctx, volumeID, request)
+}
+
+// DetachByDropletID a storage volume from a Droplet by Droplet ID.
+func (s *StorageActionsServiceOp) DetachByDropletID(ctx context.Context, volumeID string, dropletID int) (*Action, *Response, error) {
+	request := &ActionRequest{
+		"type":       "detach",
+		"droplet_id": dropletID,
+	}
+	return s.doAction(ctx, volumeID, request)
+}
+
+// Get an action for a particular storage volume by id.
+func (s *StorageActionsServiceOp) Get(ctx context.Context, volumeID string, actionID int) (*Action, *Response, error) {
+	path := fmt.Sprintf("%s/%d", storageAllocationActionPath(volumeID), actionID)
+	return s.get(ctx, path)
+}
+
+// List the actions for a particular storage volume.
+func (s *StorageActionsServiceOp) List(ctx context.Context, volumeID string, opt *ListOptions) ([]Action, *Response, error) {
+	path := storageAllocationActionPath(volumeID)
+	path, err := addOptions(path, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.list(ctx, path)
+}
+
+// Resize a storage volume.
+func (s *StorageActionsServiceOp) Resize(ctx context.Context, volumeID string, sizeGigabytes int, regionSlug string) (*Action, *Response, error) {
+	request := &ActionRequest{
+		"type":           "resize",
+		"size_gigabytes": sizeGigabytes,
+		"region":         regionSlug,
+	}
+	return s.doAction(ctx, volumeID, request)
+}
+
+func (s *StorageActionsServiceOp) doAction(ctx context.Context, volumeID string, request *ActionRequest) (*Action, *Response, error) {
+	path := storageAllocationActionPath(volumeID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+func (s *StorageActionsServiceOp) get(ctx context.Context, path string) (*Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Event, resp, err
+}
+
+func (s *StorageActionsServiceOp) list(ctx context.Context, path string) ([]Action, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(actionsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Actions, resp, err
+}
+
+func storageAllocationActionPath(volumeID string) string {
+	return fmt.Sprintf("%s/%s/actions", storageAllocPath, volumeID)
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/strings.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/strings.go
@@ -1,0 +1,92 @@
+package godo
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+)
+
+var timestampType = reflect.TypeOf(Timestamp{})
+
+// Stringify attempts to create a string representation of DigitalOcean types
+func Stringify(message interface{}) string {
+	var buf bytes.Buffer
+	v := reflect.ValueOf(message)
+	stringifyValue(&buf, v)
+	return buf.String()
+}
+
+// stringifyValue was graciously cargoculted from the goprotubuf library
+func stringifyValue(w io.Writer, val reflect.Value) {
+	if val.Kind() == reflect.Ptr && val.IsNil() {
+		_, _ = w.Write([]byte("<nil>"))
+		return
+	}
+
+	v := reflect.Indirect(val)
+
+	switch v.Kind() {
+	case reflect.String:
+		fmt.Fprintf(w, `"%s"`, v)
+	case reflect.Slice:
+		stringifySlice(w, v)
+		return
+	case reflect.Struct:
+		stringifyStruct(w, v)
+	default:
+		if v.CanInterface() {
+			fmt.Fprint(w, v.Interface())
+		}
+	}
+}
+
+func stringifySlice(w io.Writer, v reflect.Value) {
+	_, _ = w.Write([]byte{'['})
+	for i := 0; i < v.Len(); i++ {
+		if i > 0 {
+			_, _ = w.Write([]byte{' '})
+		}
+
+		stringifyValue(w, v.Index(i))
+	}
+
+	_, _ = w.Write([]byte{']'})
+}
+
+func stringifyStruct(w io.Writer, v reflect.Value) {
+	if v.Type().Name() != "" {
+		_, _ = w.Write([]byte(v.Type().String()))
+	}
+
+	// special handling of Timestamp values
+	if v.Type() == timestampType {
+		fmt.Fprintf(w, "{%s}", v.Interface())
+		return
+	}
+
+	_, _ = w.Write([]byte{'{'})
+
+	var sep bool
+	for i := 0; i < v.NumField(); i++ {
+		fv := v.Field(i)
+		if fv.Kind() == reflect.Ptr && fv.IsNil() {
+			continue
+		}
+		if fv.Kind() == reflect.Slice && fv.IsNil() {
+			continue
+		}
+
+		if sep {
+			_, _ = w.Write([]byte(", "))
+		} else {
+			sep = true
+		}
+
+		_, _ = w.Write([]byte(v.Type().Field(i).Name))
+		_, _ = w.Write([]byte{':'})
+		stringifyValue(w, fv)
+	}
+
+	_, _ = w.Write([]byte{'}'})
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/tags.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/tags.go
@@ -1,0 +1,209 @@
+package godo
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo/context"
+)
+
+const tagsBasePath = "v2/tags"
+
+// TagsService is an interface for interfacing with the tags
+// endpoints of the DigitalOcean API
+// See: https://developers.digitalocean.com/documentation/v2#tags
+type TagsService interface {
+	List(context.Context, *ListOptions) ([]Tag, *Response, error)
+	Get(context.Context, string) (*Tag, *Response, error)
+	Create(context.Context, *TagCreateRequest) (*Tag, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+
+	TagResources(context.Context, string, *TagResourcesRequest) (*Response, error)
+	UntagResources(context.Context, string, *UntagResourcesRequest) (*Response, error)
+}
+
+// TagsServiceOp handles communication with tag related method of the
+// DigitalOcean API.
+type TagsServiceOp struct {
+	client *Client
+}
+
+var _ TagsService = &TagsServiceOp{}
+
+// ResourceType represents a class of resource, currently only droplet are supported
+type ResourceType string
+
+const (
+	//DropletResourceType holds the string representing our ResourceType of Droplet.
+	DropletResourceType ResourceType = "droplet"
+)
+
+// Resource represent a single resource for associating/disassociating with tags
+type Resource struct {
+	ID   string       `json:"resource_id,omit_empty"`
+	Type ResourceType `json:"resource_type,omit_empty"`
+}
+
+// TaggedResources represent the set of resources a tag is attached to
+type TaggedResources struct {
+	Droplets *TaggedDropletsResources `json:"droplets,omitempty"`
+}
+
+// TaggedDropletsResources represent the droplet resources a tag is attached to
+type TaggedDropletsResources struct {
+	Count      int      `json:"count,float64,omitempty"`
+	LastTagged *Droplet `json:"last_tagged,omitempty"`
+}
+
+// Tag represent DigitalOcean tag
+type Tag struct {
+	Name      string           `json:"name,omitempty"`
+	Resources *TaggedResources `json:"resources,omitempty"`
+}
+
+//TagCreateRequest represents the JSON structure of a request of that type.
+type TagCreateRequest struct {
+	Name string `json:"name"`
+}
+
+// TagResourcesRequest represents the JSON structure of a request of that type.
+type TagResourcesRequest struct {
+	Resources []Resource `json:"resources"`
+}
+
+// UntagResourcesRequest represents the JSON structure of a request of that type.
+type UntagResourcesRequest struct {
+	Resources []Resource `json:"resources"`
+}
+
+type tagsRoot struct {
+	Tags  []Tag  `json:"tags"`
+	Links *Links `json:"links"`
+}
+
+type tagRoot struct {
+	Tag *Tag `json:"tag"`
+}
+
+// List all tags
+func (s *TagsServiceOp) List(ctx context.Context, opt *ListOptions) ([]Tag, *Response, error) {
+	path := tagsBasePath
+	path, err := addOptions(path, opt)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(tagsRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Tags, resp, err
+}
+
+// Get a single tag
+func (s *TagsServiceOp) Get(ctx context.Context, name string) (*Tag, *Response, error) {
+	path := fmt.Sprintf("%s/%s", tagsBasePath, name)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(tagRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Tag, resp, err
+}
+
+// Create a new tag
+func (s *TagsServiceOp) Create(ctx context.Context, createRequest *TagCreateRequest) (*Tag, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, tagsBasePath, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(tagRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Tag, resp, err
+}
+
+// Delete an existing tag
+func (s *TagsServiceOp) Delete(ctx context.Context, name string) (*Response, error) {
+	if name == "" {
+		return nil, NewArgError("name", "cannot be empty")
+	}
+
+	path := fmt.Sprintf("%s/%s", tagsBasePath, name)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// TagResources associates resources with a given Tag.
+func (s *TagsServiceOp) TagResources(ctx context.Context, name string, tagRequest *TagResourcesRequest) (*Response, error) {
+	if name == "" {
+		return nil, NewArgError("name", "cannot be empty")
+	}
+
+	if tagRequest == nil {
+		return nil, NewArgError("tagRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("%s/%s/resources", tagsBasePath, name)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, tagRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// UntagResources dissociates resources with a given Tag.
+func (s *TagsServiceOp) UntagResources(ctx context.Context, name string, untagRequest *UntagResourcesRequest) (*Response, error) {
+	if name == "" {
+		return nil, NewArgError("name", "cannot be empty")
+	}
+
+	if untagRequest == nil {
+		return nil, NewArgError("tagRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf("%s/%s/resources", tagsBasePath, name)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, untagRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/provider/digitalocean/vendor/github.com/digitalocean/godo/timestamp.go
+++ b/provider/digitalocean/vendor/github.com/digitalocean/godo/timestamp.go
@@ -1,0 +1,35 @@
+package godo
+
+import (
+	"strconv"
+	"time"
+)
+
+// Timestamp represents a time that can be unmarshalled from a JSON string
+// formatted as either an RFC3339 or Unix timestamp. All
+// exported methods of time.Time can be called on Timestamp.
+type Timestamp struct {
+	time.Time
+}
+
+func (t Timestamp) String() string {
+	return t.Time.String()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// Time is expected in RFC3339 or Unix format.
+func (t *Timestamp) UnmarshalJSON(data []byte) error {
+	str := string(data)
+	i, err := strconv.ParseInt(str, 10, 64)
+	if err == nil {
+		t.Time = time.Unix(i, 0)
+	} else {
+		t.Time, err = time.Parse(`"`+time.RFC3339+`"`, str)
+	}
+	return err
+}
+
+// Equal reports whether t and u are equal based on time.Equal
+func (t Timestamp) Equal(u Timestamp) bool {
+	return t.Time.Equal(u.Time)
+}

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/AUTHORS
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/CONTRIBUTING.md
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to Go
+
+Go is an open source project.
+
+It is the work of hundreds of contributors. We appreciate your help!
+
+
+## Filing issues
+
+When [filing an issue](https://github.com/golang/oauth2/issues), make sure to answer these five questions:
+
+1. What version of Go are you using (`go version`)?
+2. What operating system and processor architecture are you using?
+3. What did you do?
+4. What did you expect to see?
+5. What did you see instead?
+
+General questions should go to the [golang-nuts mailing list](https://groups.google.com/group/golang-nuts) instead of the issue tracker.
+The gophers there will answer or ask you to file an issue if you've tripped over a bug.
+
+## Contributing code
+
+Please read the [Contribution Guidelines](https://golang.org/doc/contribute.html)
+before sending patches.
+
+**We do not accept GitHub pull requests**
+(we use [Gerrit](https://code.google.com/p/gerrit/) instead for code review).
+
+Unless otherwise noted, the Go source files are distributed under
+the BSD-style license found in the LICENSE file.
+

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/CONTRIBUTORS
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/LICENSE
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The oauth2 Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/README.md
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/README.md
@@ -1,0 +1,64 @@
+# OAuth2 for Go
+
+[![Build Status](https://travis-ci.org/golang/oauth2.svg?branch=master)](https://travis-ci.org/golang/oauth2)
+
+oauth2 package contains a client implementation for OAuth 2.0 spec.
+
+## Installation
+
+~~~~
+go get golang.org/x/oauth2
+~~~~
+
+See godoc for further documentation and examples.
+
+* [godoc.org/golang.org/x/oauth2](http://godoc.org/golang.org/x/oauth2)
+* [godoc.org/golang.org/x/oauth2/google](http://godoc.org/golang.org/x/oauth2/google)
+
+
+## App Engine
+
+In change 96e89be (March 2015) we removed the `oauth2.Context2` type in favor
+of the [`context.Context`](https://golang.org/x/net/context#Context) type from
+the `golang.org/x/net/context` package
+
+This means its no longer possible to use the "Classic App Engine"
+`appengine.Context` type with the `oauth2` package. (You're using
+Classic App Engine if you import the package `"appengine"`.)
+
+To work around this, you may use the new `"google.golang.org/appengine"`
+package. This package has almost the same API as the `"appengine"` package,
+but it can be fetched with `go get` and used on "Managed VMs" and well as
+Classic App Engine.
+
+See the [new `appengine` package's readme](https://github.com/golang/appengine#updating-a-go-app-engine-app)
+for information on updating your app.
+
+If you don't want to update your entire app to use the new App Engine packages,
+you may use both sets of packages in parallel, using only the new packages
+with the `oauth2` package.
+
+	import (
+		"golang.org/x/net/context"
+		"golang.org/x/oauth2"
+		"golang.org/x/oauth2/google"
+		newappengine "google.golang.org/appengine"
+		newurlfetch "google.golang.org/appengine/urlfetch"
+
+		"appengine"
+	)
+
+	func handler(w http.ResponseWriter, r *http.Request) {
+		var c appengine.Context = appengine.NewContext(r)
+		c.Infof("Logging a message with the old package")
+
+		var ctx context.Context = newappengine.NewContext(r)
+		client := &http.Client{
+			Transport: &oauth2.Transport{
+				Source: google.AppEngineTokenSource(ctx, "scope"),
+				Base:   &newurlfetch.Transport{Context: ctx},
+			},
+		}
+		client.Get("...")
+	}
+

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/client_appengine.go
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/client_appengine.go
@@ -1,0 +1,25 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+// App Engine hooks.
+
+package oauth2
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/internal"
+	"google.golang.org/appengine/urlfetch"
+)
+
+func init() {
+	internal.RegisterContextClientFunc(contextClientAppEngine)
+}
+
+func contextClientAppEngine(ctx context.Context) (*http.Client, error) {
+	return urlfetch.Client(ctx), nil
+}

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/internal/oauth2.go
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/internal/oauth2.go
@@ -1,0 +1,76 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package internal contains support packages for oauth2 package.
+package internal
+
+import (
+	"bufio"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ParseKey converts the binary contents of a private key file
+// to an *rsa.PrivateKey. It detects whether the private key is in a
+// PEM container or not. If so, it extracts the the private key
+// from PEM container before conversion. It only supports PEM
+// containers with no passphrase.
+func ParseKey(key []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(key)
+	if block != nil {
+		key = block.Bytes
+	}
+	parsedKey, err := x509.ParsePKCS8PrivateKey(key)
+	if err != nil {
+		parsedKey, err = x509.ParsePKCS1PrivateKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("private key should be a PEM or plain PKSC1 or PKCS8; parse error: %v", err)
+		}
+	}
+	parsed, ok := parsedKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("private key is invalid")
+	}
+	return parsed, nil
+}
+
+func ParseINI(ini io.Reader) (map[string]map[string]string, error) {
+	result := map[string]map[string]string{
+		"": map[string]string{}, // root section
+	}
+	scanner := bufio.NewScanner(ini)
+	currentSection := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, ";") {
+			// comment.
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			currentSection = strings.TrimSpace(line[1 : len(line)-1])
+			result[currentSection] = map[string]string{}
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 && parts[0] != "" {
+			result[currentSection][strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error scanning ini: %v", err)
+	}
+	return result, nil
+}
+
+func CondVal(v string) []string {
+	if v == "" {
+		return nil
+	}
+	return []string{v}
+}

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/internal/token.go
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/internal/token.go
@@ -1,0 +1,225 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package internal contains support packages for oauth2 package.
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// Token represents the crendentials used to authorize
+// the requests to access protected resources on the OAuth 2.0
+// provider's backend.
+//
+// This type is a mirror of oauth2.Token and exists to break
+// an otherwise-circular dependency. Other internal packages
+// should convert this Token into an oauth2.Token before use.
+type Token struct {
+	// AccessToken is the token that authorizes and authenticates
+	// the requests.
+	AccessToken string
+
+	// TokenType is the type of token.
+	// The Type method returns either this or "Bearer", the default.
+	TokenType string
+
+	// RefreshToken is a token that's used by the application
+	// (as opposed to the user) to refresh the access token
+	// if it expires.
+	RefreshToken string
+
+	// Expiry is the optional expiration time of the access token.
+	//
+	// If zero, TokenSource implementations will reuse the same
+	// token forever and RefreshToken or equivalent
+	// mechanisms for that TokenSource will not be used.
+	Expiry time.Time
+
+	// Raw optionally contains extra metadata from the server
+	// when updating a token.
+	Raw interface{}
+}
+
+// tokenJSON is the struct representing the HTTP response from OAuth2
+// providers returning a token in JSON form.
+type tokenJSON struct {
+	AccessToken  string         `json:"access_token"`
+	TokenType    string         `json:"token_type"`
+	RefreshToken string         `json:"refresh_token"`
+	ExpiresIn    expirationTime `json:"expires_in"` // at least PayPal returns string, while most return number
+	Expires      expirationTime `json:"expires"`    // broken Facebook spelling of expires_in
+}
+
+func (e *tokenJSON) expiry() (t time.Time) {
+	if v := e.ExpiresIn; v != 0 {
+		return time.Now().Add(time.Duration(v) * time.Second)
+	}
+	if v := e.Expires; v != 0 {
+		return time.Now().Add(time.Duration(v) * time.Second)
+	}
+	return
+}
+
+type expirationTime int32
+
+func (e *expirationTime) UnmarshalJSON(b []byte) error {
+	var n json.Number
+	err := json.Unmarshal(b, &n)
+	if err != nil {
+		return err
+	}
+	i, err := n.Int64()
+	if err != nil {
+		return err
+	}
+	*e = expirationTime(i)
+	return nil
+}
+
+var brokenAuthHeaderProviders = []string{
+	"https://accounts.google.com/",
+	"https://api.dropbox.com/",
+	"https://api.dropboxapi.com/",
+	"https://api.instagram.com/",
+	"https://api.netatmo.net/",
+	"https://api.odnoklassniki.ru/",
+	"https://api.pushbullet.com/",
+	"https://api.soundcloud.com/",
+	"https://api.twitch.tv/",
+	"https://app.box.com/",
+	"https://connect.stripe.com/",
+	"https://login.microsoftonline.com/",
+	"https://login.salesforce.com/",
+	"https://oauth.sandbox.trainingpeaks.com/",
+	"https://oauth.trainingpeaks.com/",
+	"https://oauth.vk.com/",
+	"https://openapi.baidu.com/",
+	"https://slack.com/",
+	"https://test-sandbox.auth.corp.google.com",
+	"https://test.salesforce.com/",
+	"https://user.gini.net/",
+	"https://www.douban.com/",
+	"https://www.googleapis.com/",
+	"https://www.linkedin.com/",
+	"https://www.strava.com/oauth/",
+	"https://www.wunderlist.com/oauth/",
+	"https://api.patreon.com/",
+}
+
+func RegisterBrokenAuthHeaderProvider(tokenURL string) {
+	brokenAuthHeaderProviders = append(brokenAuthHeaderProviders, tokenURL)
+}
+
+// providerAuthHeaderWorks reports whether the OAuth2 server identified by the tokenURL
+// implements the OAuth2 spec correctly
+// See https://code.google.com/p/goauth2/issues/detail?id=31 for background.
+// In summary:
+// - Reddit only accepts client secret in the Authorization header
+// - Dropbox accepts either it in URL param or Auth header, but not both.
+// - Google only accepts URL param (not spec compliant?), not Auth header
+// - Stripe only accepts client secret in Auth header with Bearer method, not Basic
+func providerAuthHeaderWorks(tokenURL string) bool {
+	for _, s := range brokenAuthHeaderProviders {
+		if strings.HasPrefix(tokenURL, s) {
+			// Some sites fail to implement the OAuth2 spec fully.
+			return false
+		}
+	}
+
+	// Assume the provider implements the spec properly
+	// otherwise. We can add more exceptions as they're
+	// discovered. We will _not_ be adding configurable hooks
+	// to this package to let users select server bugs.
+	return true
+}
+
+func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string, v url.Values) (*Token, error) {
+	hc, err := ContextClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	v.Set("client_id", clientID)
+	bustedAuth := !providerAuthHeaderWorks(tokenURL)
+	if bustedAuth && clientSecret != "" {
+		v.Set("client_secret", clientSecret)
+	}
+	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(v.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if !bustedAuth {
+		req.SetBasicAuth(clientID, clientSecret)
+	}
+	r, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
+	}
+	if code := r.StatusCode; code < 200 || code > 299 {
+		return nil, fmt.Errorf("oauth2: cannot fetch token: %v\nResponse: %s", r.Status, body)
+	}
+
+	var token *Token
+	content, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	switch content {
+	case "application/x-www-form-urlencoded", "text/plain":
+		vals, err := url.ParseQuery(string(body))
+		if err != nil {
+			return nil, err
+		}
+		token = &Token{
+			AccessToken:  vals.Get("access_token"),
+			TokenType:    vals.Get("token_type"),
+			RefreshToken: vals.Get("refresh_token"),
+			Raw:          vals,
+		}
+		e := vals.Get("expires_in")
+		if e == "" {
+			// TODO(jbd): Facebook's OAuth2 implementation is broken and
+			// returns expires_in field in expires. Remove the fallback to expires,
+			// when Facebook fixes their implementation.
+			e = vals.Get("expires")
+		}
+		expires, _ := strconv.Atoi(e)
+		if expires != 0 {
+			token.Expiry = time.Now().Add(time.Duration(expires) * time.Second)
+		}
+	default:
+		var tj tokenJSON
+		if err = json.Unmarshal(body, &tj); err != nil {
+			return nil, err
+		}
+		token = &Token{
+			AccessToken:  tj.AccessToken,
+			TokenType:    tj.TokenType,
+			RefreshToken: tj.RefreshToken,
+			Expiry:       tj.expiry(),
+			Raw:          make(map[string]interface{}),
+		}
+		json.Unmarshal(body, &token.Raw) // no error checks for optional fields
+	}
+	// Don't overwrite `RefreshToken` with an empty value
+	// if this was a token refreshing request.
+	if token.RefreshToken == "" {
+		token.RefreshToken = v.Get("refresh_token")
+	}
+	return token, nil
+}

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/internal/transport.go
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/internal/transport.go
@@ -1,0 +1,69 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package internal contains support packages for oauth2 package.
+package internal
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+// HTTPClient is the context key to use with golang.org/x/net/context's
+// WithValue function to associate an *http.Client value with a context.
+var HTTPClient ContextKey
+
+// ContextKey is just an empty struct. It exists so HTTPClient can be
+// an immutable public variable with a unique type. It's immutable
+// because nobody else can create a ContextKey, being unexported.
+type ContextKey struct{}
+
+// ContextClientFunc is a func which tries to return an *http.Client
+// given a Context value. If it returns an error, the search stops
+// with that error.  If it returns (nil, nil), the search continues
+// down the list of registered funcs.
+type ContextClientFunc func(context.Context) (*http.Client, error)
+
+var contextClientFuncs []ContextClientFunc
+
+func RegisterContextClientFunc(fn ContextClientFunc) {
+	contextClientFuncs = append(contextClientFuncs, fn)
+}
+
+func ContextClient(ctx context.Context) (*http.Client, error) {
+	if ctx != nil {
+		if hc, ok := ctx.Value(HTTPClient).(*http.Client); ok {
+			return hc, nil
+		}
+	}
+	for _, fn := range contextClientFuncs {
+		c, err := fn(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if c != nil {
+			return c, nil
+		}
+	}
+	return http.DefaultClient, nil
+}
+
+func ContextTransport(ctx context.Context) http.RoundTripper {
+	hc, err := ContextClient(ctx)
+	// This is a rare error case (somebody using nil on App Engine).
+	if err != nil {
+		return ErrorTransport{err}
+	}
+	return hc.Transport
+}
+
+// ErrorTransport returns the specified error on RoundTrip.
+// This RoundTripper should be used in rare error cases where
+// error handling can be postponed to response handling time.
+type ErrorTransport struct{ Err error }
+
+func (t ErrorTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, t.Err
+}

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/oauth2.go
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/oauth2.go
@@ -1,0 +1,339 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package oauth2 provides support for making
+// OAuth2 authorized and authenticated HTTP requests.
+// It can additionally grant authorization with Bearer JWT.
+package oauth2 // import "golang.org/x/oauth2"
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/internal"
+)
+
+// NoContext is the default context you should supply if not using
+// your own context.Context (see https://golang.org/x/net/context).
+var NoContext = context.TODO()
+
+// RegisterBrokenAuthHeaderProvider registers an OAuth2 server
+// identified by the tokenURL prefix as an OAuth2 implementation
+// which doesn't support the HTTP Basic authentication
+// scheme to authenticate with the authorization server.
+// Once a server is registered, credentials (client_id and client_secret)
+// will be passed as query parameters rather than being present
+// in the Authorization header.
+// See https://code.google.com/p/goauth2/issues/detail?id=31 for background.
+func RegisterBrokenAuthHeaderProvider(tokenURL string) {
+	internal.RegisterBrokenAuthHeaderProvider(tokenURL)
+}
+
+// Config describes a typical 3-legged OAuth2 flow, with both the
+// client application information and the server's endpoint URLs.
+// For the client credentials 2-legged OAuth2 flow, see the clientcredentials
+// package (https://golang.org/x/oauth2/clientcredentials).
+type Config struct {
+	// ClientID is the application's ID.
+	ClientID string
+
+	// ClientSecret is the application's secret.
+	ClientSecret string
+
+	// Endpoint contains the resource server's token endpoint
+	// URLs. These are constants specific to each server and are
+	// often available via site-specific packages, such as
+	// google.Endpoint or github.Endpoint.
+	Endpoint Endpoint
+
+	// RedirectURL is the URL to redirect users going through
+	// the OAuth flow, after the resource owner's URLs.
+	RedirectURL string
+
+	// Scope specifies optional requested permissions.
+	Scopes []string
+}
+
+// A TokenSource is anything that can return a token.
+type TokenSource interface {
+	// Token returns a token or an error.
+	// Token must be safe for concurrent use by multiple goroutines.
+	// The returned Token must not be modified.
+	Token() (*Token, error)
+}
+
+// Endpoint contains the OAuth 2.0 provider's authorization and token
+// endpoint URLs.
+type Endpoint struct {
+	AuthURL  string
+	TokenURL string
+}
+
+var (
+	// AccessTypeOnline and AccessTypeOffline are options passed
+	// to the Options.AuthCodeURL method. They modify the
+	// "access_type" field that gets sent in the URL returned by
+	// AuthCodeURL.
+	//
+	// Online is the default if neither is specified. If your
+	// application needs to refresh access tokens when the user
+	// is not present at the browser, then use offline. This will
+	// result in your application obtaining a refresh token the
+	// first time your application exchanges an authorization
+	// code for a user.
+	AccessTypeOnline  AuthCodeOption = SetAuthURLParam("access_type", "online")
+	AccessTypeOffline AuthCodeOption = SetAuthURLParam("access_type", "offline")
+
+	// ApprovalForce forces the users to view the consent dialog
+	// and confirm the permissions request at the URL returned
+	// from AuthCodeURL, even if they've already done so.
+	ApprovalForce AuthCodeOption = SetAuthURLParam("approval_prompt", "force")
+)
+
+// An AuthCodeOption is passed to Config.AuthCodeURL.
+type AuthCodeOption interface {
+	setValue(url.Values)
+}
+
+type setParam struct{ k, v string }
+
+func (p setParam) setValue(m url.Values) { m.Set(p.k, p.v) }
+
+// SetAuthURLParam builds an AuthCodeOption which passes key/value parameters
+// to a provider's authorization endpoint.
+func SetAuthURLParam(key, value string) AuthCodeOption {
+	return setParam{key, value}
+}
+
+// AuthCodeURL returns a URL to OAuth 2.0 provider's consent page
+// that asks for permissions for the required scopes explicitly.
+//
+// State is a token to protect the user from CSRF attacks. You must
+// always provide a non-zero string and validate that it matches the
+// the state query parameter on your redirect callback.
+// See http://tools.ietf.org/html/rfc6749#section-10.12 for more info.
+//
+// Opts may include AccessTypeOnline or AccessTypeOffline, as well
+// as ApprovalForce.
+func (c *Config) AuthCodeURL(state string, opts ...AuthCodeOption) string {
+	var buf bytes.Buffer
+	buf.WriteString(c.Endpoint.AuthURL)
+	v := url.Values{
+		"response_type": {"code"},
+		"client_id":     {c.ClientID},
+		"redirect_uri":  internal.CondVal(c.RedirectURL),
+		"scope":         internal.CondVal(strings.Join(c.Scopes, " ")),
+		"state":         internal.CondVal(state),
+	}
+	for _, opt := range opts {
+		opt.setValue(v)
+	}
+	if strings.Contains(c.Endpoint.AuthURL, "?") {
+		buf.WriteByte('&')
+	} else {
+		buf.WriteByte('?')
+	}
+	buf.WriteString(v.Encode())
+	return buf.String()
+}
+
+// PasswordCredentialsToken converts a resource owner username and password
+// pair into a token.
+//
+// Per the RFC, this grant type should only be used "when there is a high
+// degree of trust between the resource owner and the client (e.g., the client
+// is part of the device operating system or a highly privileged application),
+// and when other authorization grant types are not available."
+// See https://tools.ietf.org/html/rfc6749#section-4.3 for more info.
+//
+// The HTTP client to use is derived from the context.
+// If nil, http.DefaultClient is used.
+func (c *Config) PasswordCredentialsToken(ctx context.Context, username, password string) (*Token, error) {
+	return retrieveToken(ctx, c, url.Values{
+		"grant_type": {"password"},
+		"username":   {username},
+		"password":   {password},
+		"scope":      internal.CondVal(strings.Join(c.Scopes, " ")),
+	})
+}
+
+// Exchange converts an authorization code into a token.
+//
+// It is used after a resource provider redirects the user back
+// to the Redirect URI (the URL obtained from AuthCodeURL).
+//
+// The HTTP client to use is derived from the context.
+// If a client is not provided via the context, http.DefaultClient is used.
+//
+// The code will be in the *http.Request.FormValue("code"). Before
+// calling Exchange, be sure to validate FormValue("state").
+func (c *Config) Exchange(ctx context.Context, code string) (*Token, error) {
+	return retrieveToken(ctx, c, url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"redirect_uri": internal.CondVal(c.RedirectURL),
+		"scope":        internal.CondVal(strings.Join(c.Scopes, " ")),
+	})
+}
+
+// Client returns an HTTP client using the provided token.
+// The token will auto-refresh as necessary. The underlying
+// HTTP transport will be obtained using the provided context.
+// The returned client and its Transport should not be modified.
+func (c *Config) Client(ctx context.Context, t *Token) *http.Client {
+	return NewClient(ctx, c.TokenSource(ctx, t))
+}
+
+// TokenSource returns a TokenSource that returns t until t expires,
+// automatically refreshing it as necessary using the provided context.
+//
+// Most users will use Config.Client instead.
+func (c *Config) TokenSource(ctx context.Context, t *Token) TokenSource {
+	tkr := &tokenRefresher{
+		ctx:  ctx,
+		conf: c,
+	}
+	if t != nil {
+		tkr.refreshToken = t.RefreshToken
+	}
+	return &reuseTokenSource{
+		t:   t,
+		new: tkr,
+	}
+}
+
+// tokenRefresher is a TokenSource that makes "grant_type"=="refresh_token"
+// HTTP requests to renew a token using a RefreshToken.
+type tokenRefresher struct {
+	ctx          context.Context // used to get HTTP requests
+	conf         *Config
+	refreshToken string
+}
+
+// WARNING: Token is not safe for concurrent access, as it
+// updates the tokenRefresher's refreshToken field.
+// Within this package, it is used by reuseTokenSource which
+// synchronizes calls to this method with its own mutex.
+func (tf *tokenRefresher) Token() (*Token, error) {
+	if tf.refreshToken == "" {
+		return nil, errors.New("oauth2: token expired and refresh token is not set")
+	}
+
+	tk, err := retrieveToken(tf.ctx, tf.conf, url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {tf.refreshToken},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if tf.refreshToken != tk.RefreshToken {
+		tf.refreshToken = tk.RefreshToken
+	}
+	return tk, err
+}
+
+// reuseTokenSource is a TokenSource that holds a single token in memory
+// and validates its expiry before each call to retrieve it with
+// Token. If it's expired, it will be auto-refreshed using the
+// new TokenSource.
+type reuseTokenSource struct {
+	new TokenSource // called when t is expired.
+
+	mu sync.Mutex // guards t
+	t  *Token
+}
+
+// Token returns the current token if it's still valid, else will
+// refresh the current token (using r.Context for HTTP client
+// information) and return the new one.
+func (s *reuseTokenSource) Token() (*Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.t.Valid() {
+		return s.t, nil
+	}
+	t, err := s.new.Token()
+	if err != nil {
+		return nil, err
+	}
+	s.t = t
+	return t, nil
+}
+
+// StaticTokenSource returns a TokenSource that always returns the same token.
+// Because the provided token t is never refreshed, StaticTokenSource is only
+// useful for tokens that never expire.
+func StaticTokenSource(t *Token) TokenSource {
+	return staticTokenSource{t}
+}
+
+// staticTokenSource is a TokenSource that always returns the same Token.
+type staticTokenSource struct {
+	t *Token
+}
+
+func (s staticTokenSource) Token() (*Token, error) {
+	return s.t, nil
+}
+
+// HTTPClient is the context key to use with golang.org/x/net/context's
+// WithValue function to associate an *http.Client value with a context.
+var HTTPClient internal.ContextKey
+
+// NewClient creates an *http.Client from a Context and TokenSource.
+// The returned client is not valid beyond the lifetime of the context.
+//
+// As a special case, if src is nil, a non-OAuth2 client is returned
+// using the provided context. This exists to support related OAuth2
+// packages.
+func NewClient(ctx context.Context, src TokenSource) *http.Client {
+	if src == nil {
+		c, err := internal.ContextClient(ctx)
+		if err != nil {
+			return &http.Client{Transport: internal.ErrorTransport{Err: err}}
+		}
+		return c
+	}
+	return &http.Client{
+		Transport: &Transport{
+			Base:   internal.ContextTransport(ctx),
+			Source: ReuseTokenSource(nil, src),
+		},
+	}
+}
+
+// ReuseTokenSource returns a TokenSource which repeatedly returns the
+// same token as long as it's valid, starting with t.
+// When its cached token is invalid, a new token is obtained from src.
+//
+// ReuseTokenSource is typically used to reuse tokens from a cache
+// (such as a file on disk) between runs of a program, rather than
+// obtaining new tokens unnecessarily.
+//
+// The initial token t may be nil, in which case the TokenSource is
+// wrapped in a caching version if it isn't one already. This also
+// means it's always safe to wrap ReuseTokenSource around any other
+// TokenSource without adverse effects.
+func ReuseTokenSource(t *Token, src TokenSource) TokenSource {
+	// Don't wrap a reuseTokenSource in itself. That would work,
+	// but cause an unnecessary number of mutex operations.
+	// Just build the equivalent one.
+	if rt, ok := src.(*reuseTokenSource); ok {
+		if t == nil {
+			// Just use it directly.
+			return rt
+		}
+		src = rt.new
+	}
+	return &reuseTokenSource{
+		t:   t,
+		new: src,
+	}
+}

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/token.go
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/token.go
@@ -1,0 +1,158 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package oauth2
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/internal"
+)
+
+// expiryDelta determines how earlier a token should be considered
+// expired than its actual expiration time. It is used to avoid late
+// expirations due to client-server time mismatches.
+const expiryDelta = 10 * time.Second
+
+// Token represents the crendentials used to authorize
+// the requests to access protected resources on the OAuth 2.0
+// provider's backend.
+//
+// Most users of this package should not access fields of Token
+// directly. They're exported mostly for use by related packages
+// implementing derivative OAuth2 flows.
+type Token struct {
+	// AccessToken is the token that authorizes and authenticates
+	// the requests.
+	AccessToken string `json:"access_token"`
+
+	// TokenType is the type of token.
+	// The Type method returns either this or "Bearer", the default.
+	TokenType string `json:"token_type,omitempty"`
+
+	// RefreshToken is a token that's used by the application
+	// (as opposed to the user) to refresh the access token
+	// if it expires.
+	RefreshToken string `json:"refresh_token,omitempty"`
+
+	// Expiry is the optional expiration time of the access token.
+	//
+	// If zero, TokenSource implementations will reuse the same
+	// token forever and RefreshToken or equivalent
+	// mechanisms for that TokenSource will not be used.
+	Expiry time.Time `json:"expiry,omitempty"`
+
+	// raw optionally contains extra metadata from the server
+	// when updating a token.
+	raw interface{}
+}
+
+// Type returns t.TokenType if non-empty, else "Bearer".
+func (t *Token) Type() string {
+	if strings.EqualFold(t.TokenType, "bearer") {
+		return "Bearer"
+	}
+	if strings.EqualFold(t.TokenType, "mac") {
+		return "MAC"
+	}
+	if strings.EqualFold(t.TokenType, "basic") {
+		return "Basic"
+	}
+	if t.TokenType != "" {
+		return t.TokenType
+	}
+	return "Bearer"
+}
+
+// SetAuthHeader sets the Authorization header to r using the access
+// token in t.
+//
+// This method is unnecessary when using Transport or an HTTP Client
+// returned by this package.
+func (t *Token) SetAuthHeader(r *http.Request) {
+	r.Header.Set("Authorization", t.Type()+" "+t.AccessToken)
+}
+
+// WithExtra returns a new Token that's a clone of t, but using the
+// provided raw extra map. This is only intended for use by packages
+// implementing derivative OAuth2 flows.
+func (t *Token) WithExtra(extra interface{}) *Token {
+	t2 := new(Token)
+	*t2 = *t
+	t2.raw = extra
+	return t2
+}
+
+// Extra returns an extra field.
+// Extra fields are key-value pairs returned by the server as a
+// part of the token retrieval response.
+func (t *Token) Extra(key string) interface{} {
+	if raw, ok := t.raw.(map[string]interface{}); ok {
+		return raw[key]
+	}
+
+	vals, ok := t.raw.(url.Values)
+	if !ok {
+		return nil
+	}
+
+	v := vals.Get(key)
+	switch s := strings.TrimSpace(v); strings.Count(s, ".") {
+	case 0: // Contains no "."; try to parse as int
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return i
+		}
+	case 1: // Contains a single "."; try to parse as float
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return f
+		}
+	}
+
+	return v
+}
+
+// expired reports whether the token is expired.
+// t must be non-nil.
+func (t *Token) expired() bool {
+	if t.Expiry.IsZero() {
+		return false
+	}
+	return t.Expiry.Add(-expiryDelta).Before(time.Now())
+}
+
+// Valid reports whether t is non-nil, has an AccessToken, and is not expired.
+func (t *Token) Valid() bool {
+	return t != nil && t.AccessToken != "" && !t.expired()
+}
+
+// tokenFromInternal maps an *internal.Token struct into
+// a *Token struct.
+func tokenFromInternal(t *internal.Token) *Token {
+	if t == nil {
+		return nil
+	}
+	return &Token{
+		AccessToken:  t.AccessToken,
+		TokenType:    t.TokenType,
+		RefreshToken: t.RefreshToken,
+		Expiry:       t.Expiry,
+		raw:          t.Raw,
+	}
+}
+
+// retrieveToken takes a *Config and uses that to retrieve an *internal.Token.
+// This token is then mapped from *internal.Token into an *oauth2.Token which is returned along
+// with an error..
+func retrieveToken(ctx context.Context, c *Config, v url.Values) (*Token, error) {
+	tk, err := internal.RetrieveToken(ctx, c.ClientID, c.ClientSecret, c.Endpoint.TokenURL, v)
+	if err != nil {
+		return nil, err
+	}
+	return tokenFromInternal(tk), nil
+}

--- a/provider/digitalocean/vendor/golang.org/x/oauth2/transport.go
+++ b/provider/digitalocean/vendor/golang.org/x/oauth2/transport.go
@@ -1,0 +1,132 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package oauth2
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+)
+
+// Transport is an http.RoundTripper that makes OAuth 2.0 HTTP requests,
+// wrapping a base RoundTripper and adding an Authorization header
+// with a token from the supplied Sources.
+//
+// Transport is a low-level mechanism. Most code will use the
+// higher-level Config.Client method instead.
+type Transport struct {
+	// Source supplies the token to add to outgoing requests'
+	// Authorization headers.
+	Source TokenSource
+
+	// Base is the base RoundTripper used to make HTTP requests.
+	// If nil, http.DefaultTransport is used.
+	Base http.RoundTripper
+
+	mu     sync.Mutex                      // guards modReq
+	modReq map[*http.Request]*http.Request // original -> modified
+}
+
+// RoundTrip authorizes and authenticates the request with an
+// access token. If no token exists or token is expired,
+// tries to refresh/fetch a new token.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.Source == nil {
+		return nil, errors.New("oauth2: Transport's Source is nil")
+	}
+	token, err := t.Source.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	req2 := cloneRequest(req) // per RoundTripper contract
+	token.SetAuthHeader(req2)
+	t.setModReq(req, req2)
+	res, err := t.base().RoundTrip(req2)
+	if err != nil {
+		t.setModReq(req, nil)
+		return nil, err
+	}
+	res.Body = &onEOFReader{
+		rc: res.Body,
+		fn: func() { t.setModReq(req, nil) },
+	}
+	return res, nil
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t *Transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base().(canceler); ok {
+		t.mu.Lock()
+		modReq := t.modReq[req]
+		delete(t.modReq, req)
+		t.mu.Unlock()
+		cr.CancelRequest(modReq)
+	}
+}
+
+func (t *Transport) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
+	}
+	return http.DefaultTransport
+}
+
+func (t *Transport) setModReq(orig, mod *http.Request) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.modReq == nil {
+		t.modReq = make(map[*http.Request]*http.Request)
+	}
+	if mod == nil {
+		delete(t.modReq, orig)
+	} else {
+		t.modReq[orig] = mod
+	}
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header, len(r.Header))
+	for k, s := range r.Header {
+		r2.Header[k] = append([]string(nil), s...)
+	}
+	return r2
+}
+
+type onEOFReader struct {
+	rc io.ReadCloser
+	fn func()
+}
+
+func (r *onEOFReader) Read(p []byte) (n int, err error) {
+	n, err = r.rc.Read(p)
+	if err == io.EOF {
+		r.runFunc()
+	}
+	return
+}
+
+func (r *onEOFReader) Close() error {
+	err := r.rc.Close()
+	r.runFunc()
+	return err
+}
+
+func (r *onEOFReader) runFunc() {
+	if fn := r.fn; fn != nil {
+		fn()
+		r.fn = nil
+	}
+}

--- a/provider/digitalocean/vendor/vendor.json
+++ b/provider/digitalocean/vendor/vendor.json
@@ -1,0 +1,25 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "zTi0sr6hUeeShuLKjC+bg1r40Uw=",
+			"path": "github.com/digitalocean/godo",
+			"revision": "6590ae2b11308f9e4434392ca45117b02e150be5",
+			"revisionTime": "2017-09-23T15:50:20Z"
+		},
+		{
+			"checksumSHA1": "yNdgWHw0jfiNAO9E7IfrbyiuKVc=",
+			"path": "golang.org/x/oauth2",
+			"revision": "3b966c7f301c0c71c53d94dc632a62df0a682cd7",
+			"revisionTime": "2016-07-25T20:29:55Z"
+		},
+		{
+			"checksumSHA1": "D3v/aqfB9swlaZcSksCoF+lbOqo=",
+			"path": "golang.org/x/oauth2/internal",
+			"revision": "3b966c7f301c0c71c53d94dc632a62df0a682cd7",
+			"revisionTime": "2016-07-25T20:29:55Z"
+		}
+	],
+	"rootPath": "github.com/hashicorp/go-discover/provider/digitalocean"
+}


### PR DESCRIPTION
Verified with this snippet: 

```
package main

import (
	"fmt"
	"log"
	"os"

	"github.com/hashicorp/go-discover"
)

func main() {
	l := log.New(os.Stderr, "", log.LstdFlags)
	args := fmt.Sprintf("provider=digitalocean region=nyc3 tag_value=consul-server api_key=%s", os.Getenv("DIGITALOCEAN_API_KEY"))
	d := discover.Discover{}
	addrs, err := d.Addrs(args, l)
	if err != nil {
		log.Println("error discovering servers")
	}
	log.Printf("%v\n", addrs)
}
```

Output:
```
2017/09/26 23:55:16 [DEBUG] discover: Using provider "digitalocean"
2017/09/26 23:55:16 [INFO] discover-digitalocean: Region is "nyc3"
2017/09/26 23:55:16 [INFO] discover-digitalocean: Address type  is not supported. Valid values are {private_v4,public_v4,public_v6}. Falling back to 'public_v4'
2017/09/26 23:55:17 [INFO] discover-digitalocean: Found instance (xxxxxx) <hostname1> with IP: X.X.X.X
2017/09/26 23:55:17 [INFO] discover-digitalocean: Found instance (xxxxxx) <hostname2> with IP: Y.Y.Y.Y
2017/09/26 23:55:17 [INFO] discover-digitalocean: Found instance (37696506) blahblahblah with IP: Z.Z.Z.Z
2017/09/26 23:55:17 [X.X.X.X Y.Y.Y.Y Z.Z.Z.Z]
```