### PR TITLE
Provide a way to set custom user agents for clients

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -31,6 +31,13 @@ type Provider interface {
 	Help() string
 }
 
+// ProviderWithUserAgent is a provider that declares it's user agent. Not all
+// providers support this.
+type ProviderWithUserAgent interface {
+	// SetUserAgent sets the user agent on the provider to the provided string.
+	SetUserAgent(s string)
+}
+
 // Providers contains all available providers.
 var Providers = map[string]Provider{
 	"aliyun":       &aliyun.Provider{},
@@ -50,8 +57,46 @@ type Discover struct {
 	// If nil, the default list of providers is used.
 	Providers map[string]Provider
 
+	// userAgent is the string to use for requests, when supported.
+	userAgent string
+
 	// once is used to initialize the actual list of providers.
 	once sync.Once
+}
+
+// Option is used as an initialization option/
+type Option func(*Discover) error
+
+// New creates a new discover client with the given options.
+func New(opts ...Option) (*Discover, error) {
+	d := new(Discover)
+
+	for _, opt := range opts {
+		if err := opt(d); err != nil {
+			return nil, err
+		}
+	}
+
+	d.once.Do(d.initProviders)
+
+	return d, nil
+}
+
+// WithUserAgent allows specifying a custom user agent option to send with
+// requests when the underlying client library supports it.
+func WithUserAgent(agent string) Option {
+	return func(d *Discover) error {
+		d.userAgent = agent
+		return nil
+	}
+}
+
+// WithProviders allows specifying your own set of providers.
+func WithProviders(m map[string]Provider) Option {
+	return func(d *Discover) error {
+		d.Providers = m
+		return nil
+	}
 }
 
 // initProviders sets the list of providers to the
@@ -121,6 +166,11 @@ func (d *Discover) Addrs(cfg string, l *log.Logger) ([]string, error) {
 		return nil, fmt.Errorf("discover: unknown provider " + name)
 	}
 	l.Printf("[DEBUG] discover: Using provider %q", name)
+
+	if typ, ok := p.(ProviderWithUserAgent); ok {
+		typ.SetUserAgent(d.userAgent)
+		return p.Addrs(args, l)
+	}
 
 	return p.Addrs(args, l)
 }

--- a/provider/aliyun/aliyun_discover.go
+++ b/provider/aliyun/aliyun_discover.go
@@ -10,7 +10,13 @@ import (
 	"github.com/denverdino/aliyungo/ecs"
 )
 
-type Provider struct{}
+type Provider struct {
+	userAgent string
+}
+
+func (p *Provider) SetUserAgent(s string) {
+	p.userAgent = s
+}
 
 func (p *Provider) Help() string {
 	return `Aliyun(Alibaba Cloud):
@@ -56,6 +62,10 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 	l.Printf("[INFO] discover-aliyun: Region is %s", region)
 
 	svc := ecs.NewClient(accessKeyID, accessKeySecret)
+
+	if p.userAgent != "" {
+		svc.SetUserAgent(p.userAgent)
+	}
 
 	l.Printf("[INFO] discover-aliyun: Filter instances with %s=%s", tagKey, tagValue)
 	resp, err := svc.DescribeInstancesWithRaw(&ecs.DescribeInstancesArgs{

--- a/provider/aliyun/aliyun_discover_test.go
+++ b/provider/aliyun/aliyun_discover_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/hashicorp/go-discover/provider/aliyun"
 )
 
+var _ discover.Provider = (*aliyun.Provider)(nil)
+var _ discover.ProviderWithUserAgent = (*aliyun.Provider)(nil)
+
 func TestAddrs(t *testing.T) {
 	args := discover.Config{
 		"provider":          "aliyun",

--- a/provider/azure/azure_discover.go
+++ b/provider/azure/azure_discover.go
@@ -13,7 +13,13 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 )
 
-type Provider struct{}
+type Provider struct {
+	userAgent string
+}
+
+func (p *Provider) SetUserAgent(s string) {
+	p.userAgent = s
+}
 
 func (p *Provider) Help() string {
 	return `Microsoft Azure:
@@ -78,9 +84,12 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 
 	// Setup the client using autorest; followed the structure from Terraform
 	vmnet := network.NewInterfacesClient(subscriptionID)
-	vmnet.Client.UserAgent = "Hashicorp-Consul"
 	vmnet.Sender = autorest.CreateSender(autorest.WithLogging(l))
 	vmnet.Authorizer = autorest.NewBearerAuthorizer(sbt)
+
+	if p.userAgent != "" {
+		vmnet.Client.UserAgent = p.userAgent
+	}
 
 	if tagName != "" && tagValue != "" && resourceGroup == "" && vmScaleSet == "" {
 		l.Printf("[DEBUG] discover-azure: using tag method. tag_name: %s, tag_value: %s", tagName, tagValue)

--- a/provider/azure/azure_discover_test.go
+++ b/provider/azure/azure_discover_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/hashicorp/go-discover/provider/azure"
 )
 
+var _ discover.Provider = (*azure.Provider)(nil)
+var _ discover.ProviderWithUserAgent = (*azure.Provider)(nil)
+
 func TestTagAddrs(t *testing.T) {
 	args := discover.Config{
 		"provider":          "azure",

--- a/provider/digitalocean/digitalocean_discover.go
+++ b/provider/digitalocean/digitalocean_discover.go
@@ -11,7 +11,13 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type Provider struct{}
+type Provider struct {
+	userAgent string
+}
+
+func (p *Provider) SetUserAgent(s string) {
+	p.userAgent = s
+}
 
 func (p *Provider) Help() string {
 	return `DigitalOcean:
@@ -86,6 +92,9 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 
 	oauthClient := oauth2.NewClient(context.TODO(), tokenSource)
 	client := godo.NewClient(oauthClient)
+	if p.userAgent != "" {
+		client.UserAgent = p.userAgent
+	}
 
 	droplets, err := listDropletsByTag(client, tagName)
 	if err != nil {

--- a/provider/digitalocean/digitalocean_discover_test.go
+++ b/provider/digitalocean/digitalocean_discover_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/hashicorp/go-discover/provider/digitalocean"
 )
 
+var _ discover.Provider = (*digitalocean.Provider)(nil)
+var _ discover.ProviderWithUserAgent = (*digitalocean.Provider)(nil)
+
 func TestAddrs(t *testing.T) {
 	args := discover.Config{
 		"provider":  "digitalocean",

--- a/provider/gce/gce_discover.go
+++ b/provider/gce/gce_discover.go
@@ -12,7 +12,13 @@ import (
 	compute "google.golang.org/api/compute/v1"
 )
 
-type Provider struct{}
+type Provider struct {
+	userAgent string
+}
+
+func (p *Provider) SetUserAgent(s string) {
+	p.userAgent = s
+}
 
 func (p *Provider) Help() string {
 	return `Google Cloud:
@@ -72,6 +78,9 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 	svc, err := compute.New(client)
 	if err != nil {
 		return nil, fmt.Errorf("discover-gce: %s", err)
+	}
+	if p.userAgent != "" {
+		svc.UserAgent = p.userAgent
 	}
 
 	// lookup the project zones to look in

--- a/provider/gce/gce_discover_test.go
+++ b/provider/gce/gce_discover_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/hashicorp/go-discover/provider/gce"
 )
 
+var _ discover.Provider = (*gce.Provider)(nil)
+var _ discover.ProviderWithUserAgent = (*gce.Provider)(nil)
+
 func TestAddrs(t *testing.T) {
 	// assume the google credentials file contents are in the environment,
 	// as with the terraform provider

--- a/provider/os/os_discover.go
+++ b/provider/os/os_discover.go
@@ -18,7 +18,13 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
-type Provider struct{}
+type Provider struct {
+	userAgent string
+}
+
+func (p *Provider) SetUserAgent(s string) {
+	p.userAgent = s
+}
 
 func (p *Provider) Help() string {
 	return `Openstack:
@@ -65,6 +71,10 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 	client, err := newClient(args, l)
 	if err != nil {
 		return nil, err
+	}
+
+	if p.userAgent != "" {
+		client.UserAgent.Prepend(p.userAgent)
 	}
 
 	pager := servers.List(client, ListOpts{ListOpts: servers.ListOpts{Status: "ACTIVE"}, ProjectID: projectID})

--- a/provider/os/os_discover_test.go
+++ b/provider/os/os_discover_test.go
@@ -9,6 +9,9 @@ import (
 	openstack "github.com/hashicorp/go-discover/provider/os"
 )
 
+var _ discover.Provider = (*openstack.Provider)(nil)
+var _ discover.ProviderWithUserAgent = (*openstack.Provider)(nil)
+
 func TestAddrs(t *testing.T) {
 	// todo: maybe check for http://169.254.169.254/openstack/latest/meta_data.json first
 	t.Skip("Skipping Openstack test in non-openstack env. Please enable manually")

--- a/provider/scaleway/scaleway_discover_test.go
+++ b/provider/scaleway/scaleway_discover_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/go-discover/provider/scaleway"
 )
 
+var _ discover.Provider = (*scaleway.Provider)(nil)
+
 func TestAddrs(t *testing.T) {
 	args := discover.Config{
 		"provider":     "scaleway",


### PR DESCRIPTION
This adds a new interface that providers can implement that sets a user agent string. This is useful for upstream calling libraries.

/cc umm @pearkes - not sure who is managing this library anymore. Once this is merged, we can update Consul and Nomad upstream.