### PR TITLE
Tests added for a new provider: Scaleway.

### DIFF
--- a/provider/scaleway/scaleway_discover_test.go
+++ b/provider/scaleway/scaleway_discover_test.go
@@ -12,13 +12,6 @@ import (
 var _ discover.Provider = (*scaleway.Provider)(nil)
 
 func TestAddrs(t *testing.T) {
-	//args := discover.Config{
-	//	"provider":     "scaleway",
-	//	"organization": os.Getenv("SCALEWAY_ORGANIZATION"),
-	//	"token":        os.Getenv("SCALEWAY_TOKEN"),
-	//	"tag_name":     "consul-server",
-	//	"region":       os.Getenv("SCALEWAY_REGION"),
-	//}
 	args := discover.Config{
 		"provider":     "scaleway",
 		"organization": os.Getenv("SCALEWAY_ORGANIZATION"),

--- a/provider/scaleway/scaleway_discover_test.go
+++ b/provider/scaleway/scaleway_discover_test.go
@@ -12,6 +12,13 @@ import (
 var _ discover.Provider = (*scaleway.Provider)(nil)
 
 func TestAddrs(t *testing.T) {
+	//args := discover.Config{
+	//	"provider":     "scaleway",
+	//	"organization": os.Getenv("SCALEWAY_ORGANIZATION"),
+	//	"token":        os.Getenv("SCALEWAY_TOKEN"),
+	//	"tag_name":     "consul-server",
+	//	"region":       os.Getenv("SCALEWAY_REGION"),
+	//}
 	args := discover.Config{
 		"provider":     "scaleway",
 		"organization": os.Getenv("SCALEWAY_ORGANIZATION"),
@@ -33,7 +40,7 @@ func TestAddrs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(addrs) != 3 {
+	if len(addrs) != 2 {
 		t.Fatalf("bad: %v", addrs)
 	}
 }

--- a/test/tf/scaleway/input.tf
+++ b/test/tf/scaleway/input.tf
@@ -1,0 +1,7 @@
+variable "region" {
+  default = "par1"
+}
+
+variable "image" {
+  default = "aecaed73-51a5-4439-a127-6d8229847145"
+}

--- a/test/tf/scaleway/main.tf
+++ b/test/tf/scaleway/main.tf
@@ -1,0 +1,17 @@
+//Configuring the provider
+provider "scaleway" {
+  region = "${var.region}"
+}
+resource "scaleway_server" "test" {
+  count = 2
+  image = "${var.image}"
+  type  = "C2S"
+  tags = ["consul-server"]
+  name = "test-server"
+}
+resource "scaleway_server" "dummy" {
+  image = "${var.image}"
+  name = "dummy_scaleway_instance"
+  type = "C2S"
+  tags = ["Dummy"]
+}

--- a/test/tf/scaleway/main.tf
+++ b/test/tf/scaleway/main.tf
@@ -2,16 +2,18 @@
 provider "scaleway" {
   region = "${var.region}"
 }
+
 resource "scaleway_server" "test" {
   count = 2
   image = "${var.image}"
   type  = "C2S"
-  tags = ["consul-server"]
-  name = "test-server"
+  tags  = ["consul-server"]
+  name  = "test-server"
 }
+
 resource "scaleway_server" "dummy" {
   image = "${var.image}"
-  name = "dummy_scaleway_instance"
-  type = "C2S"
-  tags = ["Dummy"]
+  name  = "dummy_scaleway_instance"
+  type  = "C2S"
+  tags  = ["Dummy"]
 }


### PR DESCRIPTION
Added terraform code for spinning up 3 Scaleway instances. Changed the provider test file to check for 2 instances with the tag "consul-server". Once, merged can test it for CI. Tests passed locally. 