### PR TITLE
CI: Use a newer version of Go, not tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: go
 
 go:
   - 1.x
-  - tip
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8.x
+  - 1.x
   - tip
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
 go:
-  - 1.x
+  - stable
 
 sudo: false


### PR DESCRIPTION
We were an old version of Go so upgraded that. Additionally removed tip given failures noted in #49. 