### PR TITLE
azure provider: added support for using alternative Azure cloud environments

### DIFF
--- a/provider/azure/azure_discover.go
+++ b/provider/azure/azure_discover.go
@@ -29,6 +29,7 @@ func (p *Provider) Help() string {
    client_id:         The id of the client
    subscription_id:   The id of the subscription
    secret_access_key: The authentication credential
+   environment:       The Azure cloud environment
 
    Use these configuration parameters when using tags:
 
@@ -69,21 +70,30 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 	// Use resourceGroup and vmScaleSet if using vm scale sets
 	resourceGroup := args["resource_group"]
 	vmScaleSet := args["vm_scale_set"]
+	environment := args["environment"]
 
-	// Only works for the Azure PublicCLoud for now; no ability to test other Environment
-	oauthConfig, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, tenantID)
+	if environment == "" {
+		environment = "AzurePublicCloud"
+	}
+
+	envConfig, err := azure.EnvironmentFromName(environment)
+	if err != nil {
+		return nil, fmt.Errorf("discover-azure: %s", err)
+	}
+
+	oauthConfig, err := adal.NewOAuthConfig(envConfig.ActiveDirectoryEndpoint, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("discover-azure: %s", err)
 	}
 
 	// Get the ServicePrincipalToken for use searching the NetworkInterfaces
-	sbt, err := adal.NewServicePrincipalToken(*oauthConfig, clientID, secretKey, azure.PublicCloud.ResourceManagerEndpoint)
+	sbt, err := adal.NewServicePrincipalToken(*oauthConfig, clientID, secretKey, envConfig.ResourceManagerEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("discover-azure: %s", err)
 	}
 
 	// Setup the client using autorest; followed the structure from Terraform
-	vmnet := network.NewInterfacesClient(subscriptionID)
+	vmnet := network.NewInterfacesClientWithBaseURI(envConfig.ResourceManagerEndpoint, subscriptionID)
 	vmnet.Sender = autorest.CreateSender(autorest.WithLogging(l))
 	vmnet.Authorizer = autorest.NewBearerAuthorizer(sbt)
 


### PR DESCRIPTION
This has been tested with Consul 1.3.0 both in the Public and US Government Azure cloud environments.