### PR TITLE
pin alicloud provider to 1.24.0

### DIFF
--- a/test/tf/aliyun/main.tf
+++ b/test/tf/aliyun/main.tf
@@ -1,4 +1,6 @@
-provider "alicloud" {}
+provider "alicloud" {
+  version = "1.24.0"
+}
 
 resource "alicloud_instance" "test" {
   count           = 2


### PR DESCRIPTION
This is to bypass the issue here: https://github.com/terraform-providers/terraform-provider-alicloud/issues/648. The latest alicloud provider and any version of the alicloud provider > 1.24.0 causes the terraform code to spin up alicloud instances to error.

The following error occurs: 
```
* alicloud_instance.test.0: Error creating Aliyun ecs instance: &errors.ServerError{httpStatus:400, requestId:"F5CDE3A6-C2E9-418F-A8D8-EA70D68839F9", hostId:"ecs-cn-hangzhou.aliyuncs.com", errorCode:"InvalidParameter.VSwitchId", recommend:"", message:"VSwitch id is required.", comment:""}
``` 