### PR TITLE
more robust alicloud test

### DIFF
--- a/provider/aliyun/aliyun_discover_test.go
+++ b/provider/aliyun/aliyun_discover_test.go
@@ -32,7 +32,7 @@ func TestAddrs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(addrs) == 0 {
+	if len(addrs) != 2 {
 		t.Fatalf("bad: %v", addrs)
 	}
 }


### PR DESCRIPTION
While the original test condition here works, checking to make sure both instances we spin up is a better check. There can be a case where only one instance spins up or go-discover finds only one instance instead of two and that can surface either a bug in go-discover or the `terraform apply` itself.

This also helps to keep this test suite consistent to the test suite of the other providers.