### PR TITLE
pin azure providers and remove Terraform output

### DIFF
--- a/test/tf/azure-vmss/main.tf
+++ b/test/tf/azure-vmss/main.tf
@@ -23,15 +23,3 @@ module "vmss" {
   location       = "${azurerm_resource_group.test.location}"
   subnet_id      = "${module.network.subnet_id}"
 }
-
-output "public_ip" {
-  value = "${module.vmss.public_ip}"
-}
-
-output "vm_scale_set" {
-  value = "${module.vmss.vm_scale_set}"
-}
-
-output "resource_group" {
-  value = "${azurerm_resource_group.test.name}"
-}

--- a/test/tf/azure-vmss/modules/vmss/main.tf
+++ b/test/tf/azure-vmss/modules/vmss/main.tf
@@ -1,5 +1,6 @@
+# pin azure provider for https://github.com/terraform-providers/terraform-provider-azurerm/pull/2035
 provider "azurerm" {
-  version = "~> 1.3"
+  version = "~> 1.16.0"
 }
 
 provider "random" {

--- a/test/tf/azurerm/main.tf
+++ b/test/tf/azurerm/main.tf
@@ -57,15 +57,3 @@ module "vm03" {
   location            = "${azurerm_resource_group.test.location}"
   subnet_id           = "${module.network.subnet_id}"
 }
-
-output "public_ips" {
-  value = ["${module.vm01.public_ip}", "${module.vm02.public_ip}", "${module.vm03.public_ip}"]
-}
-
-output "private_ips" {
-  value = ["${module.vm01.private_ip}", "${module.vm02.private_ip}", "${module.vm03.private_ip}"]
-}
-
-output "tagged_ips" {
-  value = ["${module.vm01.private_ip}", "${module.vm02.private_ip}"]
-}

--- a/test/tf/azurerm/main.tf
+++ b/test/tf/azurerm/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 1.3"
+  version = "~> 1.20.0"
 }
 
 provider "random" {


### PR DESCRIPTION
Pinning the azure provider for azure-vmss will prevent erroring on:
https://github.com/terraform-providers/terraform-provider-azurerm/pull/2035 which creates:
```
Error: module.vmss.azurerm_virtual_machine_scale_set.test: "network_profile.0.ip_configuration.0.primary": required field is not set
```