### PR TITLE
Unique Azure resource_groups and hide passwords from output

### DIFF
--- a/provider/azure/azure_discover_test.go
+++ b/provider/azure/azure_discover_test.go
@@ -15,6 +15,7 @@ var _ discover.ProviderWithUserAgent = (*azure.Provider)(nil)
 func TestTagAddrs(t *testing.T) {
 	args := discover.Config{
 		"provider":          "azure",
+		"resource_group":    "go-discover-azurerm-dev",
 		"tag_name":          "consul",
 		"tag_value":         "server",
 		"subscription_id":   os.Getenv("ARM_SUBSCRIPTION_ID"),
@@ -46,7 +47,7 @@ func TestTagAddrs(t *testing.T) {
 func TestVmScaleSetAddrs(t *testing.T) {
 	args := discover.Config{
 		"provider":          "azure",
-		"resource_group":    "go-discover-dev",
+		"resource_group":    "go-discover-azure-vmss-dev",
 		"vm_scale_set":      "go-discover-01-vmss",
 		"subscription_id":   os.Getenv("ARM_SUBSCRIPTION_ID"),
 		"tenant_id":         os.Getenv("ARM_TENANT_ID"),

--- a/test/tf/azure-vmss/main.tf
+++ b/test/tf/azure-vmss/main.tf
@@ -1,5 +1,5 @@
 variable "prefix" {
-  default = "go-discover"
+  default = "go-discover-azure-vmss"
 }
 
 resource "azurerm_resource_group" "test" {

--- a/test/tf/azure-vmss/modules/vmss/main.tf
+++ b/test/tf/azure-vmss/modules/vmss/main.tf
@@ -4,7 +4,7 @@ provider "azurerm" {
 }
 
 provider "random" {
-  version = "~> 1.2"
+  version = "~> 2.0.0"
 }
 
 resource "azurerm_public_ip" "test" {

--- a/test/tf/azurerm/main.tf
+++ b/test/tf/azurerm/main.tf
@@ -7,7 +7,7 @@ provider "random" {
 }
 
 variable "prefix" {
-  default = "go-discover"
+  default = "go-discover-azurerm"
 }
 
 resource "azurerm_resource_group" "test" {

--- a/test/tf/azurerm/main.tf
+++ b/test/tf/azurerm/main.tf
@@ -3,7 +3,7 @@ provider "azurerm" {
 }
 
 provider "random" {
-  version = "~> 1.2"
+  version = "~> 2.0.0"
 }
 
 variable "prefix" {


### PR DESCRIPTION
This PR consists of 3 different changes:

1) pin the azure version to ones that support the code base
2) add unique resource_groups so we can run both the `azurerm` and `azure-vmss` tests in parallel in the same account without Azure complaining about it
3) bump the `random` provider to 2.0.0 to hide password strings from the resource ID output in Terraform runs
before:
```
module.vmss.random_string.password: Creation complete after 0s (ID: =}@%u{c%FTkW>LLn)
```
after:
```
module.vmss.random_string.password: Creation complete after 0s (ID: none)
```