### PR TITLE
pin DO provider to 1.1.0 (latest)

### DIFF
--- a/test/tf/digitalocean/main.tf
+++ b/test/tf/digitalocean/main.tf
@@ -1,5 +1,5 @@
 provider "digitalocean" {
-  version = "~> 0.1"
+  version = "~> 1.1.0"
 }
 
 resource "digitalocean_tag" "test" {


### PR DESCRIPTION
Just pinning this to the latest version right now since the provided Terraform infrastructure code works properly with it. 