### PR TITLE
add variable for packet project

### DIFF
--- a/test/tf/packet/main.tf
+++ b/test/tf/packet/main.tf
@@ -14,8 +14,9 @@ variable "tags" {
   default = ["tag1", "tag1", "tag2", "tag3"]
 }
 
-resource "packet_project" "project" {
-  name = "go-discover:packet-project-${element(random_string.vm_name_suffix.*.result, count.index)}"
+variable "packet_project" {
+  description = "Existing packet project"
+  default     = ""
 }
 
 resource "random_string" "vm_name_suffix" {
@@ -33,5 +34,5 @@ resource "packet_device" "discover-packet01" {
   tags             = ["${element(var.tags, count.index)}"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
-  project_id       = "${packet_project.project.id}"
+  project_id       = "${var.packet_project}"
 }


### PR DESCRIPTION
This is a small change to force a user to pass in an existing project UUID rather than creating one on the fly with Terraform. 

This is most beneficial in CI where there isn't an easy way to get the output of the Terraform run into `go test` to run tests against the packet infrastructure automatically. With this PR, in CI, you can define an existing project (one that CI always uses) and set the same in `go test` so tests can run automatically.

Since this library rarely changes, I don't anticipate the uniqueness of the projects becoming an issue but if it does, we can address it in the future. With the changes in Terraform 0.12, supporting both the more hardcoded way (this way) and the more ephemeral way (creating a resource in Terraform) would be a lot easier than using ternary/count if-else hacks.