### PR TITLE
force user to input a packet project

### DIFF
--- a/test/tf/packet/main.tf
+++ b/test/tf/packet/main.tf
@@ -16,7 +16,6 @@ variable "tags" {
 
 variable "packet_project" {
   description = "Existing packet project"
-  default     = ""
 }
 
 resource "random_string" "vm_name_suffix" {


### PR DESCRIPTION
This will prevent a silent failure case when the variable isn't set. A user should have to input a project before running Terraform.