### PR TITLE
fix vm test and correct VMSS name

### DIFF
--- a/provider/azure/azure_discover_test.go
+++ b/provider/azure/azure_discover_test.go
@@ -15,7 +15,6 @@ var _ discover.ProviderWithUserAgent = (*azure.Provider)(nil)
 func TestTagAddrs(t *testing.T) {
 	args := discover.Config{
 		"provider":          "azure",
-		"resource_group":    "go-discover-azurerm-dev",
 		"tag_name":          "consul",
 		"tag_value":         "server",
 		"subscription_id":   os.Getenv("ARM_SUBSCRIPTION_ID"),
@@ -48,7 +47,7 @@ func TestVmScaleSetAddrs(t *testing.T) {
 	args := discover.Config{
 		"provider":          "azure",
 		"resource_group":    "go-discover-azure-vmss-dev",
-		"vm_scale_set":      "go-discover-01-vmss",
+		"vm_scale_set":      "go-discover-azure-vmss-01-scale-set",
 		"subscription_id":   os.Getenv("ARM_SUBSCRIPTION_ID"),
 		"tenant_id":         os.Getenv("ARM_TENANT_ID"),
 		"client_id":         os.Getenv("ARM_CLIENT_ID"),

--- a/test/tf/azure-vmss/modules/vmss/main.tf
+++ b/test/tf/azure-vmss/modules/vmss/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_lb_backend_address_pool" "bpepool" {
 }
 
 resource "azurerm_virtual_machine_scale_set" "test" {
-  name                = "${var.name}-vmss"
+  name                = "${var.name}-scale-set"
   location            = "${var.location}"
   resource_group_name = "${var.resource_group}"
   upgrade_policy_mode = "Manual"


### PR DESCRIPTION
This fixes two small bugs:

1) uses the correct` vm_scale_set` name generated from the Terraform configuration here: https://github.com/hashicorp/go-discover/blob/master/test/tf/azure-vmss/main.tf#L21

2) removes the `resource_group` argument for testing tags since tags should span across multiple `resource_groups` and only look at `tagName` and `tagValue`. https://github.com/hashicorp/go-discover/blob/master/provider/azure/azure_discover.go#L94