### PR TITLE
Use Azure MSI if no Service Principle details are provided.

### DIFF
--- a/provider/azure/azure_discover.go
+++ b/provider/azure/azure_discover.go
@@ -54,7 +54,7 @@ func (p *Provider) Help() string {
 
    When using Virtual Machine Scale Sets the only role action needed is Microsoft.Compute/virtualMachineScaleSets/*/read.
 
-   It is recommended you make a dedicated key used only for auto-joining.
+   If the Consul agent is running on an Azure instance it is recommended you use a MSI, otherwise it is recommended you make a dedicated key used only for auto-joining.
 `
 }
 


### PR DESCRIPTION
Adding the capability to use an Azure MSI.

This would be the default behaviour if the tenant_id, client_id, or secret_access_key are not specified.