### PR TITLE
Fix k8s test

### DIFF
--- a/test/tf/k8s/main.tf
+++ b/test/tf/k8s/main.tf
@@ -19,7 +19,7 @@ resource "google_container_cluster" "cluster" {
 resource "local_file" "kubeconfig" {
   filename = "${path.module}/kubeconfig.yaml"
 
-  content = <<EOF
+  sensitive_content = <<EOF
 apiVersion: v1
 clusters:
 - cluster:

--- a/test/tf/k8s/main.tf
+++ b/test/tf/k8s/main.tf
@@ -3,7 +3,8 @@ resource "random_id" "suffix" {
 }
 
 data "google_container_engine_versions" "main" {
-  zone = "${var.zone}"
+  zone           = "${var.zone}"
+  version_prefix = "1.11."
 }
 
 resource "google_container_cluster" "cluster" {

--- a/test/tf/k8s/providers.tf
+++ b/test/tf/k8s/providers.tf
@@ -1,6 +1,6 @@
 provider "google" {
   project = "${var.project}"
-  version = "~> 1.20.0"
+  version = "~> 2.2.0"
 }
 
 provider "kubernetes" {

--- a/test/tf/k8s/providers.tf
+++ b/test/tf/k8s/providers.tf
@@ -13,7 +13,7 @@ provider "kubernetes" {
 }
 
 provider "local" {
-  version = "~> 1.1.0"
+  version = "~> 1.2.0"
 }
 
 provider "random" {


### PR DESCRIPTION
This fixes the broken k8s acceptance tests. The `local_file` is now sensitive and hides the login credentials and the `version_prefix` flag is needed because of: https://github.com/terraform-providers/terraform-provider-google/issues/3369 and https://github.com/terraform-providers/terraform-provider-google/issues/3217. TL;DR for any new GKE clusters >1.12, the `master_auth` settings work differently than <1.12. By pinning the cluster to <1.12 we pass the tests.