### PR TITLE
Fix circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,10 @@ version: 2.1
 executors:
   go:
     docker:
-      - image: circleci/golang:1.11.4
+      - image: circleci/golang:1.12.5
     environment:
       - TEST_RESULTS: /tmp/test-results  # path to where test results are saved
+      - GOTESTSUM_RELEASE: 0.3.4
 
 # reusable 'commands' to be added as a step in jobs
 commands:
@@ -15,7 +16,7 @@ commands:
     parameters:
       version:
         type: string
-        default: 0.11.11
+        default: 0.11.13
       os:
         type: string
         default: linux
@@ -44,11 +45,11 @@ commands:
       - tf-install
       - checkout
 
-      - run:
-          name: install junit and setup test path
-          command: |
-            go get github.com/jstemmer/go-junit-report
-            mkdir -p /tmp/test-results
+      # make test result directory
+      - run: mkdir -p $TEST_RESULTS
+
+      # update gotestsum
+      - run: curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_RELEASE}/gotestsum_${GOTESTSUM_RELEASE}_linux_amd64.tar.gz" | sudo tar --overwrite -xz -C /usr/local/bin gotestsum
 
       # spin up infrastructure
       - run:
@@ -62,11 +63,11 @@ commands:
       - when:
           condition: << parameters.provider-go-test-tags >>
           steps:
-            - run: go test -run << parameters.provider-go-test-tags >> -v ./provider/<< parameters.provider-go-test-dir >> | tee ${TEST_RESULTS}/results.out
+            - run: gotestsum --format=short-verbose --junitfile $TEST_RESULTS/results.xml -- -run << parameters.provider-go-test-tags >> ./provider/<< parameters.provider-go-test-dir >>
       - unless:
           condition: << parameters.provider-go-test-tags >>
           steps:
-            - run: go test -v ./provider/<< parameters.provider-go-test-dir >> | tee ${TEST_RESULTS}/results.out
+            - run: gotestsum --format=short-verbose --junitfile $TEST_RESULTS/results.xml -- ./provider/<< parameters.provider-go-test-dir >>
 
       # generate XML results
       - run:
@@ -90,10 +91,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-test-v1-{{ checksum "go.sum" }}
+            - go-mod-v1-{{ checksum "go.mod" }}
       - run: go test -v
       - save_cache:
-          key: go-mod-test-v1-{{ checksum "go.sum" }}
+          key: go-mod-v1-{{ checksum "go.mod" }}
           paths:
             - /go/pkg/mod
   alicloud-provider:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,11 +69,6 @@ commands:
           steps:
             - run: gotestsum --format=short-verbose --junitfile $TEST_RESULTS/results.xml -- ./provider/<< parameters.provider-go-test-dir >>
 
-      # generate XML results
-      - run:
-          command: go-junit-report < ${TEST_RESULTS}/results.out > ${TEST_RESULTS}/results.xml
-          when: always
-
       # store test results for CircleCI
       - store_test_results:
           path: /tmp/test-results

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/denverdino/aliyungo v0.0.0-20170926055100-d3308649c661
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/digitalocean/godo v1.1.1
+	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gogo/protobuf v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/digitalocean/godo v1.1.1 h1:v0A7yF3xmKLjjdJGIeBbINfMufcrrRhqZsxuVQMoT+U=
 github.com/digitalocean/godo v1.1.1/go.mod h1:h6faOIcZ8lWIwNQ+DN7b3CgX4Kwby5T+nbpNqkUIozU=
+github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
+github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -114,6 +116,8 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3 h1:KYQXGkl6vs02hK7pK4eIbw
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519 h1:x6rhz8Y9CjbgQkccRGmELH6K+LJj7tOoh3XWeC1yaQM=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3 h1:eH6Eip3UpmR+yM/qI9Ijluzb1bNv/cAU/n+6l8tRSis=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20170807180024-9a379c6b3e95 h1:RS+wSrhdVci7CsPwJaMN8exaP3UTuQU0qB34R/E/JD0=
 golang.org/x/oauth2 v0.0.0-20170807180024-9a379c6b3e95/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=


### PR DESCRIPTION
There are a couple changes I made in CircleCI:
* bump to using go1.12.5
* use `gotestsum` to generate junit output for CircleCI test results rather than using `go-junit-report`
* use the go mod cache properly in CircleCI to reduce run times

I also ran a `go mod tidy` and the one addition to the go mod file came from:
```
go mod why -m github.com/dnaeon/go-vcr v1.0.1                                                                                                
# github.com/dnaeon/go-vcr
github.com/hashicorp/go-discover/provider/linode
github.com/linode/linodego
github.com/linode/linodego.test
github.com/dnaeon/go-vcr/recorder

# v1.0.1
(main module does not need module v1.0.1)
```

The K8S test failure will be resolved in #114 and I plan to rebase this at that time (or we can merge them separately since they don't touch the same files and master will end up having both this change and #114 in the end). 