### PR TITLE
Add customizable cmd provider

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-discover/provider/aliyun"
 	"github.com/hashicorp/go-discover/provider/aws"
 	"github.com/hashicorp/go-discover/provider/azure"
+	"github.com/hashicorp/go-discover/provider/cmd"
 	"github.com/hashicorp/go-discover/provider/digitalocean"
 	"github.com/hashicorp/go-discover/provider/gce"
 	"github.com/hashicorp/go-discover/provider/linode"
@@ -57,6 +58,7 @@ var Providers = map[string]Provider{
 	"triton":       &triton.Provider{},
 	"vsphere":      &vsphere.Provider{},
 	"packet":       &packet.Provider{},
+	"cmd":          &cmd.Provider{},
 }
 
 // Discover looks up metadata in different cloud environments.

--- a/provider/cmd/cmd_discover.go
+++ b/provider/cmd/cmd_discover.go
@@ -1,0 +1,56 @@
+// Package cmd provides node discovery via customizable cmd.
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Provider struct{}
+
+func (p *Provider) Help() string {
+	return `cmd:
+
+    provider:    "cmd"
+    cmdline:     cmdline to excute to discover node.
+	timeout:	 Timeout to wait cmdline to execute in seconds (Default 5).
+
+    The cmdline should output the node addresses line by line through stdout.
+`
+}
+
+func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error) {
+	var res bytes.Buffer
+	var err error
+	var timeout uint64 = 5
+
+	if args["provider"] != "cmd" {
+		return nil, fmt.Errorf("discover-cmd: invalid provider " + args["provider"])
+	}
+	if _, ok := args["cmdline"]; !ok {
+		return nil, fmt.Errorf("discover-cmd: missing arg cmdline")
+	}
+	if t, ok := args["timeout"]; ok {
+		timeout, err = strconv.ParseUint(t, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("discover-cmd: invalid timeout: " + t)
+		}
+	}
+	ctx, _ := context.WithTimeout(context.Background(), time.Second*time.Duration(timeout))
+	cmd := exec.CommandContext(ctx, "sh", "-c", args["cmdline"])
+
+	cmd.Stdout = &res
+	err = cmd.Run()
+
+	if err != nil {
+		return nil, fmt.Errorf("discover-cmd: excute cmd error: %s", err)
+	}
+
+	return strings.Split(res.String(), "\n"), nil
+}


### PR DESCRIPTION
This pull request adds a new cmd provider which is more customizable in some private cloud platform

```
$ discover addrs provider=cmd 'cmdline="cmdline to execute.."' timeout=1
```

```
Registered providers: [aliyun aws azure cmd digitalocean gce linode mdns os packet scaleway softlayer triton vsphere]
[DEBUG] discover: Using provider "cmd"
172.16.1.10
172.16.1.11
172.16.1.12
```

the `cmdline` should output node addresses in stdout by each line.
