### PR TITLE
Added provider for Oracle Cloud Infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cmd/discover/discover
 terraform.tfstate
 terraform.tfstate.backup
 terraform.tfvars
+.vscode/

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2
 	github.com/onsi/ginkgo v1.6.0 // indirect
 	github.com/onsi/gomega v1.4.1 // indirect
+	github.com/oracle/oci-go-sdk v5.6.0+incompatible
 	github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.1 h1:PZSj/UFNaVp3KxrzHOcS7oyuWA7LoOY/77yCTEFu21U=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
+github.com/oracle/oci-go-sdk v5.6.0+incompatible h1:SvLqCT/jr1H8yT20Iq9DGpc5f5dX92gWG2YNMkqc8fM=
+github.com/oracle/oci-go-sdk v5.6.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
 github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c h1:vwpFWvAO8DeIZfFeqASzZfsxuWPno9ncAebBEP0N3uE=
 github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c/go.mod h1:otzZQXgoO96RTzDB/Hycg0qZcXZsWJGJRSXbmEIJ+4M=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
@@ -114,6 +116,8 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3 h1:KYQXGkl6vs02hK7pK4eIbw
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519 h1:x6rhz8Y9CjbgQkccRGmELH6K+LJj7tOoh3XWeC1yaQM=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3 h1:eH6Eip3UpmR+yM/qI9Ijluzb1bNv/cAU/n+6l8tRSis=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20170807180024-9a379c6b3e95 h1:RS+wSrhdVci7CsPwJaMN8exaP3UTuQU0qB34R/E/JD0=
 golang.org/x/oauth2 v0.0.0-20170807180024-9a379c6b3e95/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=

--- a/provider/oci/oci_discover.go
+++ b/provider/oci/oci_discover.go
@@ -71,7 +71,7 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 		}		
 	}
 
-	query := fmt.Sprintf("query instance resources where (%s%s%s)", tagNamespace, tagKey, tagValue)
+	query := fmt.Sprintf("query instance resources where (lifecycleState = 'RUNNING' && %s%s%s)", tagNamespace, tagKey, tagValue)
 
 	addrType := args["addr_type"]
 

--- a/provider/oci/oci_discover.go
+++ b/provider/oci/oci_discover.go
@@ -1,0 +1,184 @@
+// Package oci provides node discovery for Oracle Cloud Infrastructure.
+package oci
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"context"
+
+	"github.com/oracle/oci-go-sdk/common"
+	"github.com/oracle/oci-go-sdk/resourcesearch"
+	"github.com/oracle/oci-go-sdk/core"
+)
+
+type Provider struct{}
+
+type Config struct{
+	tenancyOcid    string
+	userOcid       string
+	keyFingerprint string
+	region         string
+}
+
+func (p *Provider) Help() string {
+	return `Oracle Cloud Infrastructure:
+
+		provider:        "oci"
+		tag_namespace:   The namespace of the tag
+    tag_key:         The tag key to filter on
+    tag_value:       The tag value to filter on
+    addr_type:       "private" or "public". Defaults to "private".
+    tenancy_ocid:    The Tenancy OCID of the OCI account.
+		user_ocid:       The OCID of the user to use.
+		key_fingerprint: The fingerprint of the key associated with the user.
+		region:          The OCI region. Default to region of instance.
+    
+		Values for tenancy_ocid, user_ocid, key_fingerprint, and region can be omitted if these
+		are supplied in ~/.oci/config as described at
+		https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm#FileNameandLocation.		
+`
+}
+
+func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error) {
+	if args["provider"] != "oci" {
+		return nil, fmt.Errorf("discover-oci: invalid provider " + args["provider"])
+	}
+
+	if l == nil {
+		l = log.New(ioutil.Discard, "", 0)
+	}
+
+	var tagNamespace, tagKey, tagValue string
+	
+	if args["tag_namespace"] != "" {
+		tagNamespace = fmt.Sprintf("definedTags.namespace = '%s' && ", args["tag_namespace"])
+	}
+	
+	if args["tag_key"] != "" {
+		if tagNamespace != "" {
+			tagKey = fmt.Sprintf("definedTags.key = '%s'", args["tag_key"])
+		} else {
+			tagKey = fmt.Sprintf("freeformTags.key = '%s'", args["tag_key"])
+		}		
+	}
+	
+	if args["tag_value"] != "" {
+		if tagNamespace != "" {
+			tagValue = fmt.Sprintf(" && definedTags.value = '%s'", args["tag_value"])
+		} else {
+			tagValue = fmt.Sprintf(" && freeformTags.value = '%s'", args["tag_value"])
+		}		
+	}
+
+	query := fmt.Sprintf("query instance resources where (%s%s%s)", tagNamespace, tagKey, tagValue)
+
+	addrType := args["addr_type"]
+
+	var config common.ConfigurationProvider
+	// if args["tenancy_ocid"] == "" || args["user_ocid"] == "" || args["key_fingerprint"] == "" || args["region"] == "" {
+		// log.Printf("[DEBUG] discover-oci: Incomplete static configuration provided")
+		l.Printf("[DEBUG] discover-oci: Using default values from ~/.oci/config")
+		config = common.DefaultConfigProvider()
+	// } else {
+	// 	log.Printf("[DEBUG] discover-oci: Static configuration provided")
+	// 	config = Config{args["tenancy_ocid"], args["user_ocid"], args["key_fingerprint"], args["region"]}
+	// }
+	
+	if addrType != "private" && addrType != "public" {
+		l.Printf("[INFO] discover-oci: Address type: %s. Falling back to 'private'", addrType)
+		addrType = "private"
+	}
+
+	l.Printf("[DEBUG] discover-oci: Query is: %s", query)
+	
+	l.Printf("[DEBUG] discover-oci: Creating session...")
+	search, err := resourcesearch.NewResourceSearchClientWithConfigurationProvider(config)
+	if err != nil {
+		return nil, fmt.Errorf("discover-oci: NewResourceSearchClientWithConfigurationProvider failed: %s", err)
+	}
+
+	l.Printf("[INFO] discover-oci: Filter instances with %s=%s", args["tag_key"], args["tag_value"])
+	instances, err := search.SearchResources(
+		context.Background(),
+		resourcesearch.SearchResourcesRequest{
+			SearchDetails: resourcesearch.StructuredSearchDetails{Query: &query},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("discover-oci: SearchResources failed: %s", err)
+	}
+
+	l.Printf("[DEBUG] discover-oci: Found %d resources", len(instances.Items))
+	var addrs []string
+	for _, inst := range instances.Items {
+		l.Printf("[DEBUG] discover-oci: Found instance %s", *inst.Identifier)
+		compute, err := core.NewComputeClientWithConfigurationProvider(config)
+		if err != nil {
+			return nil, fmt.Errorf("discover-oci: NewComputeClientWithConfigurationProvider failed: %s", err)
+		}
+
+		attachments, err := compute.ListVnicAttachments(
+			context.Background(),
+			core.ListVnicAttachmentsRequest{
+				CompartmentId: inst.CompartmentId,
+				InstanceId: inst.Identifier,
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("discover-oci: ListVnicAttachments failed: %s", err)
+		}
+
+		l.Printf("[DEBUG] discover-oci: Instance %s has %d vnics", *inst.Identifier, len(attachments.Items))
+
+		for _, attachment := range attachments.Items {
+			l.Printf("[DEBUG] discover-oci: Checking vnic %s on Instance %s", *attachment.VnicId, *inst.Identifier)
+			vnet, err := core.NewVirtualNetworkClientWithConfigurationProvider(config)
+			if err != nil {
+				return nil, fmt.Errorf("discover-oci: NewVirtualNetworkClientWithConfigurationProvider failed: %s", err)
+			}
+
+			vnic, err := vnet.GetVnic(
+				context.Background(),
+				core.GetVnicRequest{
+					VnicId: attachment.VnicId,
+				},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("discover-oci: GetVnic failed: %s", err)
+			}
+
+			switch addrType {
+			case "private":
+				l.Printf("[INFO] discover-oci: Vnic %s on instance %s has private ip %s", *vnic.Id, *inst.Identifier, *vnic.PrivateIp)
+				addrs = append(addrs, *vnic.PrivateIp)
+			case "public":
+				if *vnic.PublicIp != "" {
+					l.Printf("[INFO] discover-oci: Vnic %s on instance %s has public ip %s", *vnic.Id, *inst.Identifier, *vnic.PublicIp)
+					addrs = append(addrs, *vnic.PublicIp)
+				} else {
+					l.Printf("[INFO] discover-oci: Vnic %s on instance %s has public ip %s", *vnic.Id, *inst.Identifier, *vnic.PublicIp)
+				}
+			}			
+		}
+	}
+
+	l.Printf("[DEBUG] discover-oci: Found ip addresses: %v", addrs)
+	return addrs, nil
+}
+
+func (c Config) TenancyOCID() (string, error) {
+	return c.tenancyOcid, nil
+}
+
+func (c Config) UserOCID() (string, error) {
+	return c.userOcid, nil
+}
+
+func (c Config) KeyFingerprint() (string, error) {
+	return c.keyFingerprint, nil
+}
+
+func (c Config) Region() (string, error) {
+	return c.region, nil
+}

--- a/provider/oci/oci_discover.go
+++ b/provider/oci/oci_discover.go
@@ -153,11 +153,11 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 				l.Printf("[INFO] discover-oci: Vnic %s on instance %s has private ip %s", *vnic.Id, *inst.Identifier, *vnic.PrivateIp)
 				addrs = append(addrs, *vnic.PrivateIp)
 			case "public":
-				if *vnic.PublicIp != "" {
+				if vnic.PublicIp != nil {
 					l.Printf("[INFO] discover-oci: Vnic %s on instance %s has public ip %s", *vnic.Id, *inst.Identifier, *vnic.PublicIp)
 					addrs = append(addrs, *vnic.PublicIp)
 				} else {
-					l.Printf("[INFO] discover-oci: Vnic %s on instance %s has public ip %s", *vnic.Id, *inst.Identifier, *vnic.PublicIp)
+					l.Printf("[INFO] discover-oci: Vnic %s on instance %s has no public ip. Skipping.", *vnic.Id, *inst.Identifier)
 				}
 			}			
 		}

--- a/provider/oci/oci_discover_test.go
+++ b/provider/oci/oci_discover_test.go
@@ -1,0 +1,28 @@
+package oci_test
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	discover "github.com/hashicorp/go-discover"
+	"github.com/hashicorp/go-discover/provider/oci"
+)
+
+func TestAddrs(t *testing.T) {
+	args := discover.Config{
+		"provider"     : "oci",
+		"tag_namespace": "discovery",
+		"tag_key"      : "consul",
+	}
+
+	p := &oci.Provider{}
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	addrs, err := p.Addrs(args, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}

--- a/provider/oci/oci_discover_test.go
+++ b/provider/oci/oci_discover_test.go
@@ -10,19 +10,66 @@ import (
 )
 
 func TestAddrs(t *testing.T) {
-	args := discover.Config{
+	freeform := discover.Config{
+		"provider" : "oci",
+		"tag_key"  : "discover",
+		"tag_value": "me",
+	}
+
+	defined := discover.Config{
 		"provider"     : "oci",
-		"tag_namespace": "discovery",
-		"tag_key"      : "consul",
+		"tag_namespace": "defined",
+		"tag_key"      : "discover",
+		"tag_value"    : "me",
+	}
+
+	freePartial := discover.Config{
+		"provider": "oci",
+		"tag_key" : "discover",
+	}
+
+	definedPartial := discover.Config{
+		"provider"     : "oci",
+		"tag_namespace": "defined",
+		"tag_key"      : "discover",
 	}
 
 	p := &oci.Provider{}
 	l := log.New(os.Stderr, "", log.LstdFlags)
-	addrs, err := p.Addrs(args, l)
+	
+	// Testing freeform tags
+	addrs, err := p.Addrs(freeform, l)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(addrs) != 1 {
+		t.Fatalf("bad: %v", addrs)
+	}
+
+	// Testing defined tags
+	addrs, err = p.Addrs(defined, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 2 {
+		t.Fatalf("bad: %v", addrs)
+	}
+
+	// Testing freeform partial tags
+	addrs, err = p.Addrs(freePartial, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("bad: %v", addrs)
+	}
+
+	// Testing defined partial tags
+	addrs, err = p.Addrs(definedPartial, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 2 {
 		t.Fatalf("bad: %v", addrs)
 	}
 }

--- a/provider/oci/oci_discover_test.go
+++ b/provider/oci/oci_discover_test.go
@@ -9,67 +9,71 @@ import (
 	"github.com/hashicorp/go-discover/provider/oci"
 )
 
+var tests = []struct {
+	name      string
+	config    discover.Config
+	addrCount int
+}{
+	{
+		"freeform",
+		discover.Config{
+			"provider" : "oci",
+			"tag_key"  : "discover",
+			"tag_value": "me",
+		},
+		1,
+	},
+	{
+		"defined",
+		discover.Config{
+			"provider"     : "oci",
+			"tag_namespace": "defined",
+			"tag_key"      : "discover",
+			"tag_value"    : "me",
+		},
+		2,
+	},
+	{
+		"freePartial",
+		discover.Config{
+			"provider": "oci",
+			"tag_key" : "discover",
+		},
+		1,
+	},
+	{
+		"definedPartial",
+		discover.Config{
+			"provider"     : "oci",
+			"tag_namespace": "defined",
+			"tag_key"      : "discover",
+		},
+		2,
+	},
+	{
+		"definedPublic",
+		discover.Config{
+			"provider"     : "oci",
+			"tag_namespace": "defined",
+			"tag_key"      : "discover",
+			"tag_value"    : "me",
+			"addr_type"    : "public",
+		},
+		1,
+	},
+}
+
 func TestAddrs(t *testing.T) {
-	freeform := discover.Config{
-		"provider" : "oci",
-		"tag_key"  : "discover",
-		"tag_value": "me",
-	}
-
-	defined := discover.Config{
-		"provider"     : "oci",
-		"tag_namespace": "defined",
-		"tag_key"      : "discover",
-		"tag_value"    : "me",
-	}
-
-	freePartial := discover.Config{
-		"provider": "oci",
-		"tag_key" : "discover",
-	}
-
-	definedPartial := discover.Config{
-		"provider"     : "oci",
-		"tag_namespace": "defined",
-		"tag_key"      : "discover",
-	}
-
 	p := &oci.Provider{}
 	l := log.New(os.Stderr, "", log.LstdFlags)
-	
-	// Testing freeform tags
-	addrs, err := p.Addrs(freeform, l)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(addrs) != 1 {
-		t.Fatalf("bad: %v", addrs)
-	}
-
-	// Testing defined tags
-	addrs, err = p.Addrs(defined, l)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(addrs) != 2 {
-		t.Fatalf("bad: %v", addrs)
-	}
-
-	// Testing freeform partial tags
-	addrs, err = p.Addrs(freePartial, l)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(addrs) != 1 {
-		t.Fatalf("bad: %v", addrs)
-	}
-
-	// Testing defined partial tags
-	addrs, err = p.Addrs(definedPartial, l)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(addrs) != 2 {
-		t.Fatalf("bad: %v", addrs)
+	for _, test := range tests {
+		l.Printf("[INFO] Begin Test: %s", test.name)
+		addrs, err := p.Addrs(test.config, l)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(addrs) != test.addrCount {
+			t.Errorf("bad: %v", addrs)
+		}
 	}
 }

--- a/test/tf/oci/input.tf
+++ b/test/tf/oci/input.tf
@@ -1,0 +1,52 @@
+data "oci_identity_availability_domains" "ads" {
+  compartment_id = "${var.tenancy_ocid}"
+}
+
+variable "tenancy_ocid" {
+  description = "The Tenancy OCID for the target account."
+}
+
+variable "user_ocid" {
+  description = "The User OCID for the target account credentials."
+}
+
+variable "fingerprint" {
+  description = "The fingerprint for the key being used to connect to OCI."
+}
+
+variable "private_key_file" {
+  description = "The path to private key to authenticate the connection OCI."
+}
+
+variable "region" {
+  description = "The region in which to create the resources."
+}
+
+variable "image_map" {
+  type        = "map"
+  description = "A map of instances keyed by the region."
+  default     = {
+    ap-seoul-1     = "ocid1.image.oc1.ap-seoul-1.aaaaaaaayajtmksg4tot2pvrezgmqbbhgul5co5flnfvx6avt23hvcdtnk3a"
+    ap-tokyo-1     = "ocid1.image.oc1.ap-tokyo-1.aaaaaaaa7ggytzvqrgjaxgylzpy4u64puuml2yjfhys4m2thznuwygdyxzzq"
+    ca-toronto-1   = "ocid1.image.oc1.ca-toronto-1.aaaaaaaanyidznndvmpfwv2uybfotbgr7rm6v5rhrecltptx2dxg76d6gdva"
+    eu-frankfurt-1 = "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaap4e7y2fyzyx57bfxg6rs5zbnbepfmvcjkezfnhnb4tjo77hl2cma"
+    uk-london-1    = "ocid1.image.oc1.uk-london-1.aaaaaaaaoy6vxajijvdxwr432alpjqfxokuuserhj7qof6vfv53o2vvxahrq"
+    us-ashburn-1   = "ocid1.image.oc1.iad.aaaaaaaa64ahfqwfhk7ft53o2vc4gz2hb7tiugfjxxaafejbin4zjbg3anpq"
+    us-phoenix-1   = "ocid1.image.oc1.phx.aaaaaaaa54bjroabxqmvzfrpq7vyp4yoga33dyfbtdaufdr2dkhubnh4szyq"
+  }
+}
+
+variable "tag_namespace" {
+  description = "The tag namespace to use for testing. Defaults to defined."
+  default     = "defined"
+}
+
+variable "tag_key" {
+  description = "The tag key to use for testing. Defaults to discover."
+  default     = "discover"
+}
+
+variable "tag_value" {
+  description = "The tag value to use for testing. Defaults to me."
+  default     = "me"
+}

--- a/test/tf/oci/main.tf
+++ b/test/tf/oci/main.tf
@@ -1,0 +1,96 @@
+provider "oci" {
+  tenancy_ocid      = "${var.tenancy_ocid}"
+  user_ocid         = "${var.user_ocid}"
+  fingerprint       = "${var.fingerprint}"
+  private_key_path  = "${var.private_key_file}"
+  region            = "${var.region}"
+}
+
+# Virtual Cloud Network
+resource "oci_core_vcn" "vcn" {
+  cidr_block     = "10.0.0.0/16"
+  compartment_id = "${var.tenancy_ocid}"
+}
+
+# Private subnet
+resource "oci_core_subnet" "private" {
+  cidr_block                 = "10.0.0.0/24"
+  compartment_id             = "${var.tenancy_ocid}"
+  vcn_id                     = "${oci_core_vcn.vcn.id}"
+  prohibit_public_ip_on_vnic = true
+}
+
+# Public subnet
+resource "oci_core_subnet" "public" {
+  cidr_block                 = "10.0.1.0/24"
+  compartment_id             = "${var.tenancy_ocid}"
+  vcn_id                     = "${oci_core_vcn.vcn.id}"
+}
+
+# Private instance with a freeform tag
+resource "oci_core_instance" "private_freeform" {
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ads.availability_domains[0], "name")}"
+  compartment_id      = "${var.tenancy_ocid}"
+  shape               = "VM.Standard2.1"
+  freeform_tags       = "${map("${var.tag_key}", "${var.tag_value}")}"
+
+  create_vnic_details {
+    subnet_id        = "${oci_core_subnet.private.id}"
+    assign_public_ip = false
+  }
+
+  source_details {
+    source_id   = "${var.image_map[var.region]}"
+    source_type = "image"
+  }
+}
+
+# Tag Namespace
+resource "oci_identity_tag_namespace" "defined" {
+  compartment_id = "${var.tenancy_ocid}"
+  description    = "For automated testing of go-discover"
+  name           = "${var.tag_namespace}"
+}
+
+resource "oci_identity_tag" "tag_key" {
+  description      = "For automated testing of go-discover"
+  name             = "${var.tag_key}"
+  tag_namespace_id = "${oci_identity_tag_namespace.defined.id}"
+}
+
+
+# Private instance with a defined tag
+resource "oci_core_instance" "private_defined" {
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ads.availability_domains[1], "name")}"
+  compartment_id      = "${var.tenancy_ocid}"
+  shape               = "VM.Standard2.1"
+  defined_tags        = "${map("${var.tag_namespace}.${var.tag_key}", "${var.tag_value}")}"
+
+  create_vnic_details {
+    subnet_id        = "${oci_core_subnet.private.id}"
+    assign_public_ip = false
+  }
+
+  source_details {
+    source_id   = "${var.image_map[var.region]}"
+    source_type = "image"
+  }
+}
+
+# Public instance
+resource "oci_core_instance" "public" {
+  availability_domain = "${lookup(data.oci_identity_availability_domains.ads.availability_domains[2], "name")}"
+  compartment_id      = "${var.tenancy_ocid}"
+  shape               = "VM.Standard2.1"
+  defined_tags        = "${map("${var.tag_namespace}.${var.tag_key}", "${var.tag_value}")}"
+
+  create_vnic_details {
+    subnet_id        = "${oci_core_subnet.public.id}"
+    assign_public_ip = true
+  }
+
+  source_details {
+    source_id   = "${var.image_map[var.region]}"
+    source_type = "image"
+  }
+}


### PR DESCRIPTION
I have two questions:

1. Do I need to do anything to vendor the oci-go-sdk?
2. I have not had the time yet to figure out processing the OCI authentication details from the provider config, instead relying on the default behavior of pulling the config from `~/.oci/config`. Will you accept it in this state (assuming I update the documentation to reflect this), or do I need to implement that before you guys will take this? 