### PR TITLE
Digitalocean multitags

### DIFF
--- a/provider/digitalocean/digitalocean_discover.go
+++ b/provider/digitalocean/digitalocean_discover.go
@@ -142,7 +142,17 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 			if privateIP != "" {
 				l.Printf("[INFO] discover-digitalocean: Found instance %s (%d) with private IP: %s", d.Name, d.ID, privateIP)
 				addrs = append(addrs, privateIP)
+			} else {
+				publicIP, err := d.PublicIPv4()
+				if err != nil {
+					return nil, fmt.Errorf("discover-digitalocean: %s", err)
+				}
+				if publicIP != "" {
+					l.Printf("[INFO] discover-digitalocean: Found instance %s (%d) with public IP: %s", d.Name, d.ID, publicIP)
+					addrs = append(addrs, publicIP)
+				}
 			}
+
 		}
 	}
 

--- a/provider/digitalocean/digitalocean_discover.go
+++ b/provider/digitalocean/digitalocean_discover.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"strings"
 
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
@@ -24,7 +25,7 @@ func (p *Provider) Help() string {
 
     provider:  "digitalocean"
     region:    The DigitalOcean region to filter on
-    tag_name:  The tag name to filter on
+    tag_names:  The tag name to filter on
     api_token: The DigitalOcean API token to use
 `
 }
@@ -40,7 +41,7 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 	return token, nil
 }
 
-func listDropletsByTag(c *godo.Client, tagName string) ([]godo.Droplet, error) {
+func listDropletsByTag(c *godo.Client, tagNames []string) ([]godo.Droplet, error) {
 	dropletList := []godo.Droplet{}
 	pageOpt := &godo.ListOptions{
 		Page:    1,
@@ -82,9 +83,9 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 	}
 
 	region := args["region"]
-	tagName := args["tag_name"]
+	tagNames := args["tag_names"]
 	apiToken := args["api_token"]
-	l.Printf("[DEBUG] discover-digitalocean: Using region=%s tag_name=%s", region, tagName)
+	l.Printf("[DEBUG] discover-digitalocean: Using region=%s tag_names=%s", region, tagNames)
 
 	tokenSource := &TokenSource{
 		AccessToken: apiToken,
@@ -96,7 +97,7 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 		client.UserAgent = p.userAgent
 	}
 
-	droplets, err := listDropletsByTag(client, tagName)
+	droplets, err := listDropletsByTag(client, tagNames)
 	if err != nil {
 		return nil, fmt.Errorf("discover-digitalocean: %s", err)
 	}

--- a/provider/digitalocean/digitalocean_discover_test.go
+++ b/provider/digitalocean/digitalocean_discover_test.go
@@ -15,7 +15,7 @@ var _ discover.ProviderWithUserAgent = (*digitalocean.Provider)(nil)
 func TestAddrs(t *testing.T) {
 	args := discover.Config{
 		"provider":  "digitalocean",
-		"tag_name":  "go-discover-test-tag",
+		"tag_names": "go-discover-test-tag1,go-discover-test-tag2",
 		"region":    "nyc3",
 		"api_token": os.Getenv("DIGITALOCEAN_TOKEN"),
 	}


### PR DESCRIPTION
While working #112, I noticed that the multi tags ability was also missing for another service provider I tend to use; DigitalOcean. I have gone ahead and added the ability. 

Also included in this PR is a small change to discover a node if the node has only a public IP on DigitalOcean. Since DigitalOcean's private network isn't always enabled, a node that doesn't have a private IP on DigitalOcean wouldn't be matched regardless of its tag match. The change here is to fall back to check for the public IP when the private IP is not available. 