### PR TITLE
ci: k8s-provider - Use latest master version for both nodes and master

### DIFF
--- a/test/tf/k8s/main.tf
+++ b/test/tf/k8s/main.tf
@@ -53,6 +53,7 @@ users:
   user:
     username: ${google_container_cluster.cluster.master_auth[0].username}
     password: ${google_container_cluster.cluster.master_auth[0].password}
+
 EOF
 
 }

--- a/test/tf/k8s/main.tf
+++ b/test/tf/k8s/main.tf
@@ -18,7 +18,7 @@ resource "google_container_cluster" "cluster" {
   initial_node_count = 5
   location           = var.zone
   min_master_version = data.google_container_engine_versions.main.latest_master_version
-  node_version       = data.google_container_engine_versions.main.latest_node_version
+  node_version       = data.google_container_engine_versions.main.latest_master_version
 
   master_auth {
     username = "go-discover"


### PR DESCRIPTION
Fixes #147

The TF provider expects the node and master version to be the same, but for some reason gcp is reporting different values for node and master.

This commit uses the master version for both to ensure they are the same.

