### PR TITLE
fix(doc): GCP service account actor is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ sub-package.
 
 ## Testing
 
-**Note: Due to the `go.sum` checksum errors referenced in [#68](https://github.com/hashicorp/go-discover/issues/68), 
+**Note: Due to the `go.sum` checksum errors referenced in [#68](https://github.com/hashicorp/go-discover/issues/68),
 you will need Go 1.11.4+ to build/test go-discover.**
 
 Configuration tests can be run with Go:
@@ -240,7 +240,8 @@ tests for some of the providers.
 1. IAM &amp; Admin / Service Accounts: Create Service Account
     * Service account name: `admin`
     * Roles:
-        * `Project/Service Account Actor`
+        * `Service Account User`
+        * `Service Account Token Creator`
         * `Compute Engine/Compute Instance Admin (v1)`
         * `Compute Engine/Compute Security Admin`
     * Furnish a new private key: `yes`


### PR DESCRIPTION
Must be replaced with `Service Account User` and `Service Account Token Creator`

See https://cloud.google.com/iam/docs/service-accounts#the_service_account_actor_role