### PR TITLE
Add Exoscale provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,12 @@ jobs:
       - acctest:
           provider-test-infra-dir: digitalocean
           provider-go-test-dir: digitalocean
+  exoscale-provider:
+    executor: go
+    steps:
+      - acctest:
+          provider-test-infra-dir: exoscale
+          provider-go-test-dir: exoscale
   gce-provider:
     executor: go
     steps:
@@ -200,6 +206,9 @@ workflows:
           requires:
             - go-test
       - digitalocean-provider:
+          requires:
+            - go-test
+      - exoscale-provider:
           requires:
             - go-test
       - gce-provider:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ function.
  * Aliyun (Alibaba) Cloud [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/aliyun/aliyun_discover.go#L15-L28)
  * Amazon AWS [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/aws/aws_discover.go#L19-L33)
  * DigitalOcean [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/digitalocean/digitalocean_discover.go#L16-L24)
+ * Exoscale [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/exoscale/exoscale_discover.go#L24-L31)
  * Google Cloud [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/gce/gce_discover.go#L17-L37)
  * Linode [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/linode/linode_discover.go#L30-L41)
  * mDNS [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/mdns/mdns_provider.go#L19-L31)
@@ -57,6 +58,9 @@ provider=aws region=eu-west-1 tag_key=consul tag_value=... access_key_id=... sec
 
 # DigitalOcean
 provider=digitalocean region=... tag_name=... api_token=...
+
+# Exoscale
+provider=exoscale zone=... tag_key=consul tag_value=... api_key=... api_secret=...
 
 # Google Cloud
 provider=gce project_name=... zone_pattern=eu-west-* tag_value=consul credentials_file=...

--- a/discover.go
+++ b/discover.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-discover/provider/aws"
 	"github.com/hashicorp/go-discover/provider/azure"
 	"github.com/hashicorp/go-discover/provider/digitalocean"
+	"github.com/hashicorp/go-discover/provider/exoscale"
 	"github.com/hashicorp/go-discover/provider/gce"
 	"github.com/hashicorp/go-discover/provider/linode"
 	"github.com/hashicorp/go-discover/provider/mdns"
@@ -49,6 +50,7 @@ var Providers = map[string]Provider{
 	"aws":          &aws.Provider{},
 	"azure":        &azure.Provider{},
 	"digitalocean": &digitalocean.Provider{},
+	"exoscale":     &exoscale.Provider{},
 	"gce":          &gce.Provider{},
 	"linode":       &linode.Provider{},
 	"mdns":         &mdns.Provider{},

--- a/provider/exoscale/exoscale_discover.go
+++ b/provider/exoscale/exoscale_discover.go
@@ -1,0 +1,156 @@
+// Package exoscale provides node discovery for Exoscale.
+package exoscale
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/exoscale/egoscale"
+)
+
+const (
+	defaultAPIEndpoint = "https://api.exoscale.com/v1"
+)
+
+type Provider struct{}
+
+func (p *Provider) Help() string {
+	return `Exoscale:
+
+    provider:       "exoscale"
+    api_key:        The Exoscale API key (required)
+    api_secret:     The Exoscale API secret key (required)
+    api_endpoint:   The Exoscale API endpoint
+    tag_key:        The tag key to filter on
+    tag_value:      The tag value to filter on
+    zone:           The Exoscale Zone
+    addr_type:      "public_v4" or "public_v6". (default: "public_v4")
+`
+}
+
+func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error) {
+	if args["provider"] != "exoscale" {
+		return nil, fmt.Errorf("discover-exoscale: invalid provider " + args["provider"])
+	}
+
+	if l == nil {
+		l = log.New(ioutil.Discard, "", 0)
+	}
+
+	client, err := buildClient(args)
+	if err != nil {
+		return nil, err
+	}
+
+	tagKey := args["tag_key"]
+	tagValue := args["tag_value"]
+	zone := args["zone"]
+	addrType := args["addr_type"]
+
+	if addrType == "" {
+		addrType = "public_v4"
+	}
+
+	if addrType != "public_v4" && addrType != "public_v6" {
+		l.Printf("[INFO] discover-exoscale: Address type %s is not supported. Valid values are public_v4 or public_v6. Falling back to 'public_v4'", addrType)
+		addrType = "public_v4"
+	}
+
+	l.Printf(
+		"[DEBUG] discover-exoscale: Using zone=%s tag_key=%s, tag_value=%s, addr_type=%s",
+		zone,
+		tagKey,
+		tagValue,
+		addrType,
+	)
+
+	var zoneID *egoscale.UUID
+	if zone != "" {
+		resp, err := client.Get(egoscale.Zone{Name: zone})
+		if err != nil {
+			return nil, err
+		}
+		z := resp.(*egoscale.Zone)
+		zoneID = z.ID
+	}
+
+	var tags []egoscale.ResourceTag
+	if tagKey != "" && tagValue != "" {
+		tags = []egoscale.ResourceTag{
+			{
+				Key:   tagKey,
+				Value: tagValue,
+			},
+		}
+	}
+
+	resp, err := client.RequestWithContext(context.Background(), egoscale.ListVirtualMachines{
+		ZoneID: zoneID,
+		Tags:   tags,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	instances := resp.(*egoscale.ListVirtualMachinesResponse).VirtualMachine
+
+	var addrs []string
+	for _, instance := range instances {
+		ip := instance.IP().String()
+		if addrType == "public_v6" {
+			nic := instance.DefaultNic()
+			if nic != nil {
+				if nic.IP6Address.String() == "<nil>" {
+					continue
+				}
+
+				ip = nic.IP6Address.String()
+			}
+		}
+
+		l.Printf("[DEBUG] discover-exoscale: Found instance %s - with %s IP: %s",
+			instance.Name,
+			addrType,
+			ip,
+		)
+
+		addrs = append(addrs, ip)
+	}
+
+	l.Printf("[DEBUG] discover-exoscale: Found ip addresses: %v", addrs)
+	return addrs, nil
+}
+
+func buildClient(args map[string]string) (*egoscale.Client, error) {
+	apiKey := args["api_key"]
+	apiSecret := args["api_secret"]
+	apiEndpoint := args["api_endpoint"]
+
+	apiKeyEnv := os.Getenv("EXOSCALE_API_KEY")
+	apiSecretEnv := os.Getenv("EXOSCALE_API_SECRET")
+	apiEndpointEnv := os.Getenv("EXOSCALE_API_ENDPOINT")
+
+	if apiKeyEnv != "" {
+		apiKey = apiKeyEnv
+	}
+	if apiSecretEnv != "" {
+		apiSecret = apiSecretEnv
+	}
+	if apiEndpointEnv != "" {
+		apiEndpoint = apiEndpointEnv
+	}
+
+	if apiKey == "" || apiSecret == "" {
+		return nil, errors.New("incomplete or missing for API credentials")
+	}
+
+	if apiEndpoint == "" {
+		apiEndpoint = defaultAPIEndpoint
+	}
+
+	return egoscale.NewClient(apiEndpoint, apiKey, apiSecret), nil
+}

--- a/provider/exoscale/exoscale_discover_test.go
+++ b/provider/exoscale/exoscale_discover_test.go
@@ -1,0 +1,88 @@
+package exoscale_test
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	discover "github.com/hashicorp/go-discover"
+	"github.com/hashicorp/go-discover/provider/exoscale"
+)
+
+var _ discover.Provider = (*exoscale.Provider)(nil)
+
+func TestAddrs(t *testing.T) {
+	args := discover.Config{
+		"provider":   "exoscale",
+		"api_key":    os.Getenv("EXOSCALE_API_KEY"),
+		"api_secret": os.Getenv("EXOSCALE_API_SECRET"),
+	}
+
+	p := &exoscale.Provider{}
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	addrs, err := p.Addrs(args, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 2 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}
+
+func TestAddrsZone(t *testing.T) {
+	args := discover.Config{
+		"provider":   "exoscale",
+		"api_key":    os.Getenv("EXOSCALE_API_KEY"),
+		"api_secret": os.Getenv("EXOSCALE_API_SECRET"),
+		"zone":       "ch-gva-2",
+	}
+
+	p := &exoscale.Provider{}
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	addrs, err := p.Addrs(args, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}
+
+func TestAddrsTags(t *testing.T) {
+	args := discover.Config{
+		"provider":   "exoscale",
+		"api_key":    os.Getenv("EXOSCALE_API_KEY"),
+		"api_secret": os.Getenv("EXOSCALE_API_SECRET"),
+		"tag_key":    "test-01",
+		"tag_value":  "consul",
+	}
+
+	p := &exoscale.Provider{}
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	addrs, err := p.Addrs(args, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}
+
+func TestAddrsIPv6(t *testing.T) {
+	args := discover.Config{
+		"provider":   "exoscale",
+		"api_key":    os.Getenv("EXOSCALE_API_KEY"),
+		"api_secret": os.Getenv("EXOSCALE_API_SECRET"),
+		"addr_type":  "public_v6",
+	}
+
+	p := &exoscale.Provider{}
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	addrs, err := p.Addrs(args, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}

--- a/test/tf/exoscale/input.tf
+++ b/test/tf/exoscale/input.tf
@@ -1,0 +1,9 @@
+variable "zone" {
+  default = "de-fra-1"
+}
+
+data "exoscale_compute_template" "ubuntu" {
+  zone = var.zone
+  name = "Linux Ubuntu 20.04 LTS 64-bit"
+}
+

--- a/test/tf/exoscale/main.tf
+++ b/test/tf/exoscale/main.tf
@@ -1,0 +1,30 @@
+//Configuring the provider
+provider "exoscale" {
+  version = "~> 0.15"
+}
+
+resource "exoscale_compute" "test-01" {
+  display_name = "test-01"
+  disk_size = 10
+  size = "Tiny"
+  template_id = data.exoscale_compute_template.ubuntu.id
+  zone = var.zone
+
+  tags = {
+    test-01 = "consul"
+  }
+}
+
+resource "exoscale_compute" "test-02" {
+  display_name = "test-02"
+  disk_size = 10
+  size = "Tiny"
+  template_id = data.exoscale_compute_template.ubuntu.id
+  zone = "ch-gva-2"
+
+  ip6 = true
+
+  tags = {
+    test-02 = "consul"
+  }
+}

--- a/test/tf/exoscale/versions.tf
+++ b/test/tf/exoscale/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This Pull Request add the Implementation of the Exoscale provider.

Usage
```
Exoscale:
    provider:       "exoscale"
    api_key:        The Exoscale API key (required)
    api_secret:     The Exoscale API secret key (required)
    api_endpoint:   The Exoscale API endpoint
    tag_key:        The tag key to filter on
    tag_value:      The tag value to filter on
    zone:           The Exoscale Zone
    addr_type:      "public_v4" or "public_v6". (default: "public_v4")
```