### PR TITLE
provider/hcloud: Add hcloud discovery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,12 @@ jobs:
       - acctest:
           provider-test-infra-dir: triton
           provider-go-test-dir: triton
+  hcloud-provider:
+    executor: go
+    steps:
+      - acctest:
+          provider-test-infra-dir: hcloud
+          provider-go-test-dir: hcloud
 
 workflows:
   version: 2
@@ -230,6 +236,10 @@ workflows:
             - go-test
           filters: *ignore_prs
       - triton-provider:
+          requires:
+            - go-test
+          filters: *ignore_prs
+      - hcloud-provider:
           requires:
             - go-test
           filters: *ignore_prs

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ function.
  * Triton [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/triton/triton_discover.go#L17-L27)
  * vSphere [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/vsphere/vsphere_discover.go#L148-L155)
  * Packet [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/packet/packet_discover.go#L25-L35)
+ * hcloud [Config options](https://github.com/hashicorp/go-discover/blob/master/provider/hcloud/hcloud_discover.go#L15-L23)
 
 The following providers are implemented in the go-discover/provider subdirectory
 but aren't automatically registered. If you want to support these providers,
@@ -93,6 +94,9 @@ provider=packet auth_token=token project=uuid url=... address_type=...
 
 # Kubernetes
 provider=k8s label_selector="app = consul-server"
+
+# hcloud
+provider=hcloud api_token=token label_selector=...
 ```
 
 ## Command Line Tool Usage

--- a/discover.go
+++ b/discover.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-discover/provider/azure"
 	"github.com/hashicorp/go-discover/provider/digitalocean"
 	"github.com/hashicorp/go-discover/provider/gce"
+	"github.com/hashicorp/go-discover/provider/hcloud"
 	"github.com/hashicorp/go-discover/provider/linode"
 	"github.com/hashicorp/go-discover/provider/mdns"
 	"github.com/hashicorp/go-discover/provider/os"
@@ -59,6 +60,7 @@ var Providers = map[string]Provider{
 	"triton":       &triton.Provider{},
 	"vsphere":      &vsphere.Provider{},
 	"packet":       &packet.Provider{},
+	"hcloud":       &hcloud.Provider{},
 }
 
 // Discover looks up metadata in different cloud environments.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/mdns v1.0.1
 	github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443
+	github.com/hetznercloud/hcloud-go v1.19.0
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/jarcoal/httpmock v0.0.0-20180424175123-9c70cfe4a1da // indirect
 	github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 h1:zLTLjkaOFEFIOxY5BWLFLwh+cL8vOBW4XJ2aqLE/Tf0=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
@@ -117,6 +119,8 @@ github.com/hashicorp/mdns v1.0.1 h1:XFSOubp8KWB+Jd2PDyaX5xUd5bhSP/+pTDZVDMzZJM8=
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyuqg7yuAWUg/jMZR1/0QTzTRdNR6Uw=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35nTu0ey1EXjwNwPjI9xErAsoOCmcMb9GKvyxo=
+github.com/hetznercloud/hcloud-go v1.19.0 h1:8g28MQg8Eg97K7GASKUnaTZSNKo9CB73Xfxbt/NjvnU=
+github.com/hetznercloud/hcloud-go v1.19.0/go.mod h1:EhElojlVU1biA5JgBaV8rRU1vE5+iYke402kXC9pooE=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -258,6 +262,8 @@ golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0 h1:KKgc1aqhV8wDPbDzlDtpvyjZFY3vjz85FP7p4wcQUyI=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=

--- a/provider/hcloud/hcloid_discover_test.go
+++ b/provider/hcloud/hcloid_discover_test.go
@@ -1,0 +1,87 @@
+package hcloud_test
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	discover "github.com/hashicorp/go-discover"
+	"github.com/hashicorp/go-discover/provider/hcloud"
+)
+
+var _ discover.Provider = (*hcloud.Provider)(nil)
+
+func TestAddrsPublicV4(t *testing.T) {
+	args := discover.Config{
+		"provider":  "hcloud",
+		"label_selector":  "go-discover-test-tag",
+		"api_token": os.Getenv("HCLOUD_TOKEN"),
+		"addr_type": "public_v4",
+	}
+
+	if args["api_token"] == "" {
+		t.Skip("Hetzner Cloud credentials missing")
+	}
+
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	p := &hcloud.Provider{}
+	addrs, err := p.Addrs(args, l)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(addrs) != 2 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}
+
+func TestAddrsPublicV6(t *testing.T) {
+	args := discover.Config{
+		"provider":  "hcloud",
+		"label_selector":  "go-discover-test-tag",
+		"api_token": os.Getenv("HCLOUD_TOKEN"),
+		"addr_type": "public_v6",
+	}
+
+	if args["api_token"] == "" {
+		t.Skip("Hetzner Cloud credentials missing")
+	}
+
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	p := &hcloud.Provider{}
+	addrs, err := p.Addrs(args, l)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(addrs) != 2 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}
+
+func TestAddrsPrivateV4(t *testing.T) {
+	args := discover.Config{
+		"provider":  "hcloud",
+		"label_selector":  "go-discover-test-tag",
+		"api_token": os.Getenv("HCLOUD_TOKEN"),
+		"addr_type": "private_v4",
+	}
+
+	if args["api_token"] == "" {
+		t.Skip("Hetzner Cloud credentials missing")
+	}
+
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	p := &hcloud.Provider{}
+	addrs, err := p.Addrs(args, l)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(addrs) != 2 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}

--- a/provider/hcloud/hcloud_discover.go
+++ b/provider/hcloud/hcloud_discover.go
@@ -1,0 +1,105 @@
+// Package hcloud provides node discovery for Hetzner Cloud.
+package hcloud
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	"github.com/hetznercloud/hcloud-go/hcloud"
+)
+
+type Provider struct{}
+
+func (p *Provider) Help() string {
+	return `Hetzner Cloud:
+
+    provider:       "hcloud"
+    api_token:      The Hetzner CLoud API token to use (required)
+    label_selector: The label selector to filter servers by
+    addr_type:      "private_v4", "public_v4" or "public_v6". Defaults to "private_v4". If multiple private networks are defined, the first will be used.
+`
+}
+
+func listServersByLabel(c *hcloud.Client, labelSelector string) ([]hcloud.Server, error) {
+	var serverList []hcloud.Server
+
+	opts := hcloud.ServerListOpts{
+		ListOpts: hcloud.ListOpts{
+			LabelSelector: labelSelector,
+		},
+		Status: []hcloud.ServerStatus{hcloud.ServerStatusRunning},
+	}
+
+	servers, err := c.Server.AllWithOpts(context.Background(), opts)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range servers {
+		serverList = append(serverList, *s)
+	}
+
+	return serverList, nil
+}
+
+func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error) {
+	if args["provider"] != "hcloud" {
+		return nil, fmt.Errorf("discover-hcloud: invalid provider " + args["provider"])
+	}
+
+	if l == nil {
+		l = log.New(ioutil.Discard, "", 0)
+	}
+
+	labelSelector := args["label_selector"]
+	apiToken := args["api_token"]
+	addrType := args["addr_type"]
+
+	if addrType == "" {
+		l.Printf("[DEBUG] discover-hcloud: Address type not provided. Using 'private_v4'")
+		addrType = "private_v4"
+	}
+
+	if addrType != "private_v4" && addrType != "public_v4" && addrType != "public_v6" {
+		l.Printf("[INFO] discover-hcloud: Address type %s is not supported. Valid values are {private_v4,public_v4,public_v6}. Falling back to 'private_v4'", addrType)
+		addrType = "private_v4"
+	}
+
+	l.Printf("[DEBUG] discover-hcloud: Using label_selector=%s", labelSelector)
+
+	client := hcloud.NewClient(hcloud.WithToken(apiToken))
+	servers, err := listServersByLabel(client, labelSelector)
+
+	if err != nil {
+		return nil, fmt.Errorf("discover-hcloud: %s", err)
+	}
+
+	var addrs []string
+
+	for _, s := range servers {
+		l.Printf("[INFO] discover-hcloud: Found instance %s (%d)", s.Name, s.ID)
+
+		switch addrType {
+		case "public_v4":
+			l.Printf("[INFO] discover-hcloud: Instance %s (%d) has public ip %s", s.Name, s.ID, s.PublicNet.IPv4.IP.String())
+			addrs = append(addrs, s.PublicNet.IPv4.IP.String())
+		case "private_v4":
+			if len(s.PrivateNet) == 0 {
+				l.Printf("[INFO] discover-hcloud: Instance %s (%d) has no private ip", s.Name, s.ID)
+			} else {
+				l.Printf("[INFO] discover-hcloud: Instance %s (%d) has private ip %s", s.Name, s.ID, s.PrivateNet[0].IP.String())
+				addrs = append(addrs, s.PrivateNet[0].IP.String())
+			}
+		case "public_v6":
+			l.Printf("[INFO] discover-hcloud: Instance %s (%d) has public ip %s", s.Name, s.ID, s.PublicNet.IPv6.IP.String())
+			addrs = append(addrs, s.PublicNet.IPv6.IP.String())
+		default:
+		}
+	}
+
+	l.Printf("[DEBUG] discover-hcloud: Found ip addresses: %v", addrs)
+	return addrs, nil
+}

--- a/test/tf/hcloud/input.tf
+++ b/test/tf/hcloud/input.tf
@@ -1,0 +1,15 @@
+variable "prefix" {
+  default = "go-discover"
+}
+
+variable "hcloud_image" {
+  default = "ubuntu-20.04"
+}
+
+variable "hcloud_location" {
+  default = "nbg1"
+}
+
+variable "hcloud_size" {
+  default = "cx11"
+}

--- a/test/tf/hcloud/main.tf
+++ b/test/tf/hcloud/main.tf
@@ -1,0 +1,46 @@
+provider "hcloud" {
+}
+
+resource "hcloud_server" "test-01" {
+  count       = 2
+  image       = var.hcloud_image
+  name        = "${var.prefix}-01-${count.index + 1}"
+  server_type = var.hcloud_size
+  location    = var.hcloud_location
+  labels = {
+    "${var.prefix}-test-tag" : ""
+  }
+}
+
+resource "hcloud_server" "test-02" {
+  image       = var.hcloud_image
+  name        = "${var.prefix}-02"
+  server_type = var.hcloud_size
+  location    = var.hcloud_location
+}
+
+resource "hcloud_network" "internal" {
+  name     = "${var.prefix}-internal"
+  ip_range = "10.0.0.0/8"
+  labels = {
+    "${var.prefix}-test-tag" : ""
+  }
+}
+
+resource "hcloud_network_subnet" "subnet" {
+  network_id   = hcloud_network.internal.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = "10.0.1.0/24"
+}
+
+resource "hcloud_server_network" "test-01" {
+  count     = 2
+  server_id = hcloud_server.test-01[count.index].id
+  subnet_id = hcloud_network_subnet.subnet.id
+}
+
+resource "hcloud_server_network" "test-02" {
+  server_id = hcloud_server.test-02.id
+  subnet_id = hcloud_network_subnet.subnet.id
+}

--- a/test/tf/hcloud/versions.tf
+++ b/test/tf/hcloud/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    hcloud = {
+      source  = "terraform-providers/hcloud"
+      version = "1.21.0"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This Pull Request add the Implementation of the hcloud (Hetzner Cloud) provider.

Usage

```
Hetzner Cloud:

    provider:       "hcloud"
    api_token:      The Hetzner CLoud API token to use (required)
    label_selector: The label selector to filter servers by
    addr_type:      "private_v4", "public_v4" or "public_v6". Defaults to "private_v4". If multiple private networks are defined, the first will be used.

```