### PR TITLE
Update CI badge to CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go Discover Nodes for Cloud Providers [![Build Status](https://travis-ci.org/hashicorp/go-discover.svg?branch=master)](https://travis-ci.org/hashicorp/go-discover) [![GoDoc](https://godoc.org/github.com/hashicorp/go-discover?status.svg)](https://godoc.org/github.com/hashicorp/go-discover)
+# Go Discover Nodes for Cloud Providers [![CircleCI](https://circleci.com/gh/hashicorp/go-discover.svg?style=shield)](https://circleci.com/gh/hashicorp/go-discover) [![GoDoc](https://godoc.org/github.com/hashicorp/go-discover?status.svg)](https://godoc.org/github.com/hashicorp/go-discover)
 
 
 `go-discover` is a Go (golang) library and command line tool to discover


### PR DESCRIPTION
The old badge was travis, and we have not used travis in some time.