### PR TITLE
Add AWS SessionToken Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,26 @@ commands:
       - tf-install
       - checkout
 
+      - when:
+          condition:
+            equal: [aws, << parameters.provider-test-infra-dir >>]
+          steps:
+            - run:
+                name: download and install AWS CLI
+                command: |
+                  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+                  echo -e "${AWS_CLI_GPG_KEY}" | gpg --import
+                  curl -o awscliv2.sig https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip.sig
+                  gpg --verify awscliv2.sig awscliv2.zip
+                  unzip awscliv2.zip
+                  sudo ./aws/install
+            - run:
+                name: set assume-role creds
+                command: |
+                  CREDENTIALS="$(aws sts assume-role --role-arn ${SERVICE_GO_DISCOVER_TESTS_ROLE_ARN} --role-session-name build-${CIRCLE_SHA1} | jq '.Credentials')"
+                  echo "export AWS_ACCESS_KEY_ID=$(echo $CREDENTIALS | jq -r '.AccessKeyId')" >> $BASH_ENV
+                  echo "export AWS_SECRET_ACCESS_KEY=$(echo $CREDENTIALS | jq -r '.SecretAccessKey')" >> $BASH_ENV
+                  echo "export AWS_SESSION_TOKEN=$(echo $CREDENTIALS | jq -r '.SessionToken')" >> $BASH_ENV
       # spin up infrastructure
       - run:
           working_directory: ./test/tf/<< parameters.provider-test-infra-dir >>

--- a/provider/aws/aws_discover.go
+++ b/provider/aws/aws_discover.go
@@ -48,6 +48,7 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 	addrType := args["addr_type"]
 	accessKey := args["access_key_id"]
 	secretKey := args["secret_access_key"]
+	sessionToken := args["session_token"]
 
 	if addrType != "private_v4" && addrType != "public_v4" && addrType != "public_v6" {
 		l.Printf("[INFO] discover-aws: Address type %s is not supported. Valid values are {private_v4,public_v4,public_v6}. Falling back to 'private_v4'", addrType)
@@ -87,6 +88,7 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 					Value: credentials.Value{
 						AccessKeyID:     accessKey,
 						SecretAccessKey: secretKey,
+						SessionToken:    sessionToken,
 					},
 				},
 				&credentials.EnvProvider{},

--- a/provider/aws/aws_discover_test.go
+++ b/provider/aws/aws_discover_test.go
@@ -17,6 +17,7 @@ func TestAddrs(t *testing.T) {
 		"tag_value":         "server",
 		"access_key_id":     os.Getenv("AWS_ACCESS_KEY_ID"),
 		"secret_access_key": os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		"session_token":     os.Getenv("AWS_SESSION_TOKEN"),
 	}
 
 	if args["region"] == "" || args["access_key_id"] == "" || args["secret_access_key"] == "" {


### PR DESCRIPTION
This PR adds AWS SessionToken credential support to the AWS provider in the case that you may use AssumeRole. Internally, we have changed from using a static set of AWS credentials to one that assumes a role of permissions instead so it cannot use just `AccessKeyID` and `SecretAccessKey` anymore. 

I have modified the CircleCI configuration to do the AssumeRole and setting of environment variables to support this new credential too. 

Successful run here: https://app.circleci.com/pipelines/github/hashicorp/go-discover/239/workflows/db90c9d3-4d8a-4862-9637-4b1c0c3e0626/jobs/1786

Not sure if we need to cut a new release of go-discover since this is niche use case.