### PR TITLE
Add AWS endpoint definition as an option

### DIFF
--- a/provider/aws/aws_discover_test.go
+++ b/provider/aws/aws_discover_test.go
@@ -34,3 +34,28 @@ func TestAddrs(t *testing.T) {
 		t.Fatalf("bad: %v", addrs)
 	}
 }
+func TestAddrsEndpoint(t *testing.T) {
+	args := discover.Config{
+		"provider":          "aws",
+		"region":            os.Getenv("AWS_REGION"),
+		"tag_key":           "consul",
+		"tag_value":         "server",
+		"access_key_id":     os.Getenv("AWS_ACCESS_KEY_ID"),
+		"secret_access_key": os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		"endpoint":          os.Getenv("AWS_EC2_METADATA_SERVICE_ENDPOINT"),
+	}
+
+	if args["region"] == "" || args["access_key_id"] == "" || args["secret_access_key"] == "" {
+		t.Skip("AWS credentials or region missing")
+	}
+
+	p := &aws.Provider{}
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	addrs, err := p.Addrs(args, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}


### PR DESCRIPTION
 Fixes https://github.com/hashicorp/go-discover/issues/107

inspired by  Allow setting a endpointURL on AWS provider #108 PR