### PR TITLE
explicitly list required GCP permissions

### DIFF
--- a/provider/gce/gce_discover.go
+++ b/provider/gce/gce_discover.go
@@ -39,6 +39,11 @@ func (p *Provider) Help() string {
         On other systems, $HOME/.config/gcloud/application_default_credentials.json.
      4. On Google Compute Engine, use credentials from the metadata
         server. In this final case any provided scopes are ignored.
+	
+     The GCE Service Account must have the following permissions:
+     
+     - compute.zones.list
+     - compute.instances.list
 `
 }
 


### PR DESCRIPTION
the service account used by go-discover must have the following IAM permissions:

- compute.zones.list
- compute.instances.list

This is related to issue #21 