### PR TITLE
Update tencentcloud-sdk-go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,8 @@ require (
 	github.com/sirupsen/logrus v1.0.6 // indirect
 	github.com/softlayer/softlayer-go v0.0.0-20180806151055-260589d94c7d
 	github.com/stretchr/testify v1.4.0
-	github.com/tencentcloud/tencentcloud-sdk-go v1.0.162
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480
 	github.com/vmware/govmomi v0.18.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 h1:8fDzz4GuVg4skjY2B0nMN7h6uN61EDVkuLyI2+qGHhI=
-github.com/tencentcloud/tencentcloud-sdk-go v1.0.162/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480 h1:Dwnfdrk3KXpYRH9Kwrk9sHpZSOmrE7P9LBoNsYUJKR4=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480 h1:YEDZmv2ABU8QvwXEVTOQgVEQzDOByhz73vdjL6sERkE=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480/go.mod h1:zaBIuDDs+rC74X8Aog+LSu91GFtHYRYDC196RGTm2jk=
 github.com/vmware/govmomi v0.18.0 h1:f7QxSmP7meCtoAmiKZogvVbLInT+CZx6Px6K5rYsJZo=
 github.com/vmware/govmomi v0.18.0/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=


### PR DESCRIPTION
Since dependencies are available as individual go modules now, doing a `go get -u github.com/hashicorp/go-discover/cmd/discover` fails with the below error. The PR fixes the same. 

```
#14 66.08 github.com/hashicorp/go-discover/cmd/discover imports
#14 66.08 	github.com/hashicorp/go-discover imports
#14 66.08 	github.com/hashicorp/go-discover/provider/tencentcloud imports
#14 66.08 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common: ambiguous import: found package github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common in multiple modules:
#14 66.08 	github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 (/go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go@v1.0.162/tencentcloud/common)
#14 66.08 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480 (/go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common@v1.0.480)
#14 66.08 github.com/hashicorp/go-discover/cmd/discover imports
#14 66.08 	github.com/hashicorp/go-discover imports
#14 66.08 	github.com/hashicorp/go-discover/provider/tencentcloud imports
#14 66.08 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile: ambiguous import: found package github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile in multiple modules:
#14 66.08 	github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 (/go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go@v1.0.162/tencentcloud/common/profile)
#14 66.08 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.480 (/go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common@v1.0.480/profile)
#14 66.08 github.com/hashicorp/go-discover/cmd/discover imports
#14 66.08 	github.com/hashicorp/go-discover imports
#14 66.08 	github.com/hashicorp/go-discover/provider/tencentcloud imports
#14 66.08 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312: ambiguous import: found package github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312 in multiple modules:
#14 66.08 	github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 (/go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go@v1.0.162/tencentcloud/cvm/v20170312)
#14 66.08 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.480 (/go/pkg/mod/github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm@v1.0.480/v20170312)

```