### PR TITLE
Adding the option to specify the address_type for vSphere provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ provider=tencentcloud region=ap-guangzhou tag_key=consul tag_value=... access_ke
 provider=triton account=testaccount url=https://us-sw-1.api.joyentcloud.com key_id=... tag_key=consul-role tag_value=server
 
 # vSphere
-provider=vsphere category_name=consul-role tag_name=consul-server host=... user=... password=... insecure_ssl=[true|false]
+provider=vsphere category_name=consul-role tag_name=consul-server address_type=private host=... user=... password=... insecure_ssl=[true|false]
 
 # Packet
 provider=packet auth_token=token project=uuid url=... address_type=...


### PR DESCRIPTION
According to the documentation at https://developer.hashicorp.com/consul/docs/install/cloud-auto-join the vsphere provider should return the **first** Private IP address of the hosts matching the category and tag. This does not work. The vSphere provider returns _all_ IP addresses of a host. (`net.ip.IsPrivate()` is never used in the vsphere code)

This PR adds the option for users to provide an "address_type" option that defaults to "private" so it actually returns RFC1918 addresses (as described by the documentation). Specifying "public" will return the public IP addresses.

_Full Disclosure: This is my first time actually _touching_ go-lang code. I know globals should be avoided, hence I've forwarded "addressType" to all functions to finally end up being used in the skipIPAddr function, feels nasty. No idea if there's a better solution, but it works! Feel free to implement a better method._