### PR TITLE
fixture(provider): Use only passing logger variable

### DIFF
--- a/provider/aliyun/aliyun_discover.go
+++ b/provider/aliyun/aliyun_discover.go
@@ -48,11 +48,11 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 	accessKeyID := args["access_key_id"]
 	accessKeySecret := args["access_key_secret"]
 
-	log.Printf("[DEBUG] discover-aliyun: Using region=%s tag_key=%s tag_value=%s", region, tagKey, tagValue)
+	l.Printf("[DEBUG] discover-aliyun: Using region=%s tag_key=%s tag_value=%s", region, tagKey, tagValue)
 	if accessKeyID == "" && accessKeySecret == "" {
-		log.Printf("[DEBUG] discover-aliyun: No static credentials")
+		l.Printf("[DEBUG] discover-aliyun: No static credentials")
 	} else {
-		log.Printf("[DEBUG] discover-aliyun: Static credentials provided")
+		l.Printf("[DEBUG] discover-aliyun: Static credentials provided")
 	}
 
 	if region == "" {

--- a/provider/os/os_discover.go
+++ b/provider/os/os_discover.go
@@ -67,7 +67,7 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 		args["project_id"] = projectID
 	}
 
-	log.Printf("[DEBUG] discover-os: Using project_id=%s tag_key=%s tag_value=%s", projectID, tagKey, tagValue)
+	l.Printf("[DEBUG] discover-os: Using project_id=%s tag_key=%s tag_value=%s", projectID, tagKey, tagValue)
 	client, err := newClient(args, l)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We cannot disable logging when using this package. This is because some providers use the `log` package instead of using the logger variable object passed to the `.Addrs` method in their code.