### PR TITLE
provider/azure: update vmss doc only supporting unique deployment mode

### DIFF
--- a/.github/actions/acctest/action.yml
+++ b/.github/actions/acctest/action.yml
@@ -2,13 +2,17 @@ name: acctest
 
 inputs:
   provider-test-infra-dir:
+    description: 'Specifies a directory for test infrastructure'
     required: false
   provider-go-test-dir:
+    description: 'Specifies a directory for Go tests'
     required: false
   provider-go-test-tags:
+    description: 'Test flags for go'
     required: false
     default: ''
   provider-tf-apply:
+    description: 'Applies terraform with auto-approve enabled'
     required: false
     default: terraform apply -auto-approve
   aws-region:

--- a/.github/actions/acctest/action.yml
+++ b/.github/actions/acctest/action.yml
@@ -1,5 +1,5 @@
 name: acctest
-
+description: "Acctest runs acceptance tests for go-discover"
 inputs:
   provider-test-infra-dir:
     description: 'Specifies a directory for test infrastructure'

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           gotestsum_version: 1.9.0
 
-      - uses: "./.github/actions/acctest"
+      - uses: './.github/actions/acctest'
         with:
           provider-test-infra-dir: aliyun
           provider-go-test-dir: aliyun
@@ -313,13 +313,13 @@ jobs:
   # - be placed after the fanout of a workflow so that everything fans back in
   #   to this job.
   # - "need" any job that is part of the fan out / fan in
-  # - implement the if logic because we have conditional jobs 
-  #   (go-test-enteprise) that this job needs and this would potentially get 
-  #   skipped if a previous job got skipped.  So we use the if clause to make 
+  # - implement the if logic because we have conditional jobs
+  #   (go-test-enteprise) that this job needs and this would potentially get
+  #   skipped if a previous job got skipped.  So we use the if clause to make
   # sure it does not get skipped.
 
   acceptance-success:
-    needs: 
+    needs:
     - lint
     - go-test
     - alicloud-provider

--- a/provider/azure/azure_discover.go
+++ b/provider/azure/azure_discover.go
@@ -56,6 +56,8 @@ func (p *Provider) Help() string {
    When using tags the only permission needed is Microsoft.Network/networkInterfaces/*
 
    When using Virtual Machine Scale Sets the only role action needed is Microsoft.Compute/virtualMachineScaleSets/*/read.
+   The Azure provider only supports Virtual Machine Scale Sets deployed in [Uniform mode](https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes#scale-sets-with-uniform-orchestration).
+   As of 2023 VMSS deploys using Flexible mode by default.
 
    It is recommended you make a dedicated key used only for auto-joining.
 `
@@ -130,7 +132,6 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 		l.Printf("[ERROR] discover-azure: resource_group %s, vm_scale_set %s", resourceGroup, vmScaleSet)
 		return nil, fmt.Errorf("discover-azure: unclear configuration. use (tag name and value) or (resouce_group and vm_scale_set)")
 	}
-
 }
 
 func fetchAddrsWithTags(tagName string, tagValue string, vmnet network.InterfacesClient, l *log.Logger) ([]string, error) {
@@ -139,7 +140,6 @@ func fetchAddrsWithTags(tagName string, tagValue string, vmnet network.Interface
 
 	ctx := context.Background()
 	netres, err := vmnet.ListAll(ctx)
-
 	if err != nil {
 		return nil, fmt.Errorf("discover-azure: %s", err)
 	}


### PR DESCRIPTION
Vault customers were complaining that the Azure provider does not support VMSS mode. When investigating this bug it was discovered that queries to `"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/networkInterfaces"` only returns values when VMSS is deployed in [Unique mode](https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes#scale-sets-with-uniform-orchestration).

I've updated the document to call this out.