### PR TITLE
For OpenStack, also look at OS_PROJECT_ID for the project ID.

### DIFF
--- a/provider/os/os_discover.go
+++ b/provider/os/os_discover.go
@@ -52,7 +52,7 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 		l = log.New(io.Discard, "", 0)
 	}
 
-	projectID := args["project_id"]
+	projectID := argsOrEnv(args, "project_id", "OS_PROJECT_ID")
 	tagKey := args["tag_key"]
 	tagValue := args["tag_value"]
 	var err error


### PR DESCRIPTION
In a consul configuration, you can have this to discover the consul servers in an OpenStack project:
```
"retry_join": ["provider=os tag_key=role tag_value=consulserver"]
```
Most of the usual `OS_*` environment variables are used to authenticate to OpenStack. Unfortunately it currently doesn't use `OS_PROJECT_ID`. This change improves by doing the same thing that's already done further down the source file in `newClient()`.