### PR TITLE
Make logging consistent in AWS Provider

### DIFF
--- a/provider/aws/aws_discover.go
+++ b/provider/aws/aws_discover.go
@@ -164,7 +164,7 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 			}
 		})
 
-		log.Printf("[INFO] discover-aws: Filter ECS tasks with %s=%s", tagKey, tagValue)
+		l.Printf("[INFO] discover-aws: Filter ECS tasks with %s=%s", tagKey, tagValue)
 		var clusterArns []string
 
 		// If an ECS Cluster Name (ARN) was specified, dont lookup all the cluster arns
@@ -184,7 +184,7 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 			if err != nil {
 				return nil, fmt.Errorf("discover-aws: Failed to get ECS Tasks: %s", err)
 			}
-			log.Printf("[DEBUG] discover-aws: Found %d ECS Tasks", len(taskArns))
+			l.Printf("[DEBUG] discover-aws: Found %d ECS Tasks", len(taskArns))
 
 			// Once all the possibly paged task arns are collected, collect task descriptions with 100 task maximum
 			// ref: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html#ECS-DescribeTasks-request-tasks
@@ -196,10 +196,10 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 					return nil, fmt.Errorf("discover-aws: Failed to get ECS Task IPs: %s", err)
 				}
 				taskIps = append(taskIps, ecsTaskIps...)
-				log.Printf("[DEBUG] discover-aws: Found %d ECS IPs", len(ecsTaskIps))
+				l.Printf("[DEBUG] discover-aws: Found %d ECS IPs", len(ecsTaskIps))
 			}
 		}
-		log.Printf("[DEBUG] discover-aws: Discovered ECS Task IPs: %v", taskIps)
+		l.Printf("[DEBUG] discover-aws: Discovered ECS Task IPs: %v", taskIps)
 		return taskIps, nil
 	}
 


### PR DESCRIPTION
This commit is to resolve inconsistent logging in the aws provider and updates the ECS parts to use the logger passed to the function instead of the default log package. This was raised in #269.

This was caused by the commits which introduced support for ECS not utilising the logger being passed to `addr` function and instead making a direct call to the `log` package to print the output. 

This MR updates the aws provider switching all calls of `log.Printf` to `l.Printf` and ensures that the logger is also passed to the private functions to ensure they log consistently inline with the rest of the provider code.

Before PR

```shell
$ go run main.go
{"level":"info","ts":1746121177.872697,"caller":"go-discover@v1.0.0/discover.go:178","msg":"[DEBUG] discover: Using provider \"aws\""}
{"level":"info","ts":1746121177.872697,"caller":"aws/aws_discover.go:89","msg":"[INFO] discover-aws: Address Type  is not supported for ECS. Valid values are {private_v4}. Falling back to 'private_v4'"}
{"level":"info","ts":1746121177.872697,"caller":"aws/aws_discover.go:103","msg":"[DEBUG] discover-aws: Using region=eu-west-1 tag_key=foo tag_value=bar addr_type=private_v4"}
{"level":"info","ts":1746121177.8732376,"caller":"aws/aws_discover.go:105","msg":"[DEBUG] discover-aws: No static credentials"}
{"level":"info","ts":1746121177.8732376,"caller":"aws/aws_discover.go:106","msg":"[DEBUG] discover-aws: Using environment variables, shared credentials or instance role"}
{"level":"info","ts":1746121177.8732376,"caller":"aws/aws_discover.go:135","msg":"[INFO] discover-aws: Region is eu-west-1"}
{"level":"info","ts":1746121177.8732376,"caller":"aws/aws_discover.go:137","msg":"[DEBUG] discover-aws: Creating session..."}
{"level":"info","ts":1746121177.8732376,"caller":"aws/aws_discover.go:149","msg":"[INFO] discover-aws: Using default credential chain"}
2025/05/01 18:39:37 [INFO] discover-aws: Filter ECS tasks with foo=bar
2025/05/01 18:39:38 [DEBUG] discover-aws: Retrieved 0 ClusterArns
2025/05/01 18:39:38 [DEBUG] discover-aws: Discovered ECS Task IPs: []
```

After PR
```shell
$ go run main.go
{"level":"info","ts":1746123997.240952,"caller":"go-discover@v0.0.0-20250501181514-8be573a960a7/discover.go:178","msg":"[DEBUG] discover: Using provider \"aws\""}
{"level":"info","ts":1746123997.241467,"caller":"aws/aws_discover.go:89","msg":"[INFO] discover-aws: Address Type  is not supported for ECS. Valid values are {private_v4}. Falling back to 'private_v4'"}
{"level":"info","ts":1746123997.241467,"caller":"aws/aws_discover.go:103","msg":"[DEBUG] discover-aws: Using region=eu-west-1 tag_key=foo tag_value=bar addr_type=private_v4"}
{"level":"info","ts":1746123997.241467,"caller":"aws/aws_discover.go:105","msg":"[DEBUG] discover-aws: No static credentials"}
{"level":"info","ts":1746123997.241467,"caller":"aws/aws_discover.go:106","msg":"[DEBUG] discover-aws: Using environment variables, shared credentials or instance role"}
{"level":"info","ts":1746123997.241467,"caller":"aws/aws_discover.go:135","msg":"[INFO] discover-aws: Region is eu-west-1"}
{"level":"info","ts":1746123997.241467,"caller":"aws/aws_discover.go:137","msg":"[DEBUG] discover-aws: Creating session..."}
{"level":"info","ts":1746123997.241467,"caller":"aws/aws_discover.go:149","msg":"[INFO] discover-aws: Using default credential chain"}
{"level":"info","ts":1746123997.2419846,"caller":"aws/aws_discover.go:167","msg":"[INFO] discover-aws: Filter ECS tasks with foo=bar"}
{"level":"info","ts":1746123997.425886,"caller":"aws/aws_discover.go:300","msg":"[DEBUG] discover-aws: Retrieved 0 ClusterArns"}
{"level":"info","ts":1746123997.425886,"caller":"aws/aws_discover.go:202","msg":"[DEBUG] discover-aws: Discovered ECS Task IPs: []"}

```