### PR TITLE
Enable dual-stack endpoint support for ec2 describe-instances during AWS discovery

### DIFF
--- a/provider/aws/aws_discover.go
+++ b/provider/aws/aws_discover.go
@@ -140,8 +140,11 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 	if accessKey != "" && secretKey != "" {
 		l.Printf("[INFO] discover-aws: Using static credentials provider")
 		staticCreds := credentials.NewStaticCredentialsProvider(accessKey, secretKey, sessionToken)
-		cfg, err = config.LoadDefaultConfig(context.TODO(), config.WithRegion(region),
-			config.WithCredentialsProvider(aws.NewCredentialsCache(staticCreds)))
+		cfg, err = config.LoadDefaultConfig(context.TODO(),
+			config.WithRegion(region),
+			config.WithUseDualStackEndpoint(aws.DualStackEndpointStateEnabled),
+			config.WithCredentialsProvider(aws.NewCredentialsCache(staticCreds)),
+		)
 		if err != nil {
 			l.Printf("[INFO] discover-aws: unable to load SDK config with Static Provider, %v", err)
 		}

--- a/provider/aws/aws_discover.go
+++ b/provider/aws/aws_discover.go
@@ -149,6 +149,7 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 		l.Printf("[INFO] discover-aws: Using default credential chain")
 		cfg, err = config.LoadDefaultConfig(context.TODO(),
 			config.WithRegion(region), // Specify your region
+			config.WithUseDualStackEndpoint(aws.DualStackEndpointStateEnabled),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("discover-aws: unable to load SDK config with default credential chain, %s", err)


### PR DESCRIPTION
Current AWS discovery logic fails in IPv6-only environments as `ec2 describe-instances` defaults to accessing AWS's IPv4 endpoints. This change enables dual-stack support by default, allowing the use of IPv6 endpoints where available.

Tested working in:

- [x] an IPv6-only env

- [x] an IPv4-only env