### PR TITLE
aws: fix dual-stack endpoint disable not being honored

### DIFF
--- a/cmd/test-aws-discover/README.md
+++ b/cmd/test-aws-discover/README.md
@@ -1,0 +1,75 @@
+# AWS Discover Test Tool
+
+A simple CLI tool to test the AWS discover provider, particularly the dual-stack endpoint fix.
+
+## Build
+
+### Local (macOS)
+
+```bash
+cd cmd/test-aws-discover
+go build -o test-aws-discover .
+```
+
+### Cross-compile for Linux amd64 (to run on AWS EC2)
+
+```bash
+cd cmd/test-aws-discover
+GOOS=linux GOARCH=amd64 go build -o test-aws-discover-linux-amd64 .
+```
+
+## Running on AWS EC2
+
+Copy the binary to your EC2 instance and run it. The instance's IAM role will be used for authentication.
+
+```bash
+# From your Mac, copy to EC2
+scp test-aws-discover-linux-amd64 ec2-user@<instance-ip>:~/
+
+# SSH to EC2 and run
+ssh ec2-user@<instance-ip>
+chmod +x ~/test-aws-discover-linux-amd64
+
+# Test with dual-stack disabled (the fix)
+AWS_USE_DUALSTACK_ENDPOINT=false ~/test-aws-discover-linux-amd64 -region me-central-1 -tag-key Name -tag-value my-instance
+
+# Test with dual-stack enabled (default behavior)
+~/test-aws-discover-linux-amd64 -region us-east-1 -tag-key Name -tag-value my-instance
+```
+
+## Usage
+
+```bash
+./test-aws-discover -region <region> -tag-key <key> -tag-value <value> [-addr-type <type>]
+```
+
+## Test Scenarios
+
+### 1. Test in us-east-1 with dual-stack enabled (default)
+
+```bash
+./test-aws-discover -region us-east-1 -tag-key Name -tag-value my-instance
+```
+
+### 2. Test in me-central-1 with dual-stack disabled (THE FIX)
+
+```bash
+# This should work now with the fix
+AWS_USE_DUALSTACK_ENDPOINT=false ./test-aws-discover -region me-central-1 -tag-key Name -tag-value my-instance
+```
+
+### 3. Test in me-central-1 with dual-stack enabled (will fail - no dual-stack in this region)
+
+```bash
+# This will fail because me-central-1 doesn't have dual-stack endpoints
+./test-aws-discover -region me-central-1 -tag-key Name -tag-value my-instance
+```
+
+## Expected Behavior
+
+| Region | `AWS_USE_DUALSTACK_ENDPOINT` | Expected Result |
+|--------|------------------------------|-----------------|
+| us-east-1 | `true` or unset | Works (dual-stack available) |
+| us-east-1 | `false` | Works (standard endpoints) |
+| me-central-1 | `false` | **Works (THE FIX)** |
+| me-central-1 | `true` or unset | Fails (no dual-stack in this region) |

--- a/cmd/test-aws-discover/main.go
+++ b/cmd/test-aws-discover/main.go
@@ -1,0 +1,85 @@
+// Test program for AWS discover with dual-stack endpoint support.
+// Use this to verify the fix works in regions with and without dual-stack endpoints.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	discover "github.com/hashicorp/go-discover"
+	_ "github.com/hashicorp/go-discover/provider/aws"
+)
+
+func main() {
+	region := flag.String("region", "", "AWS region (required)")
+	tagKey := flag.String("tag-key", "", "Tag key to search for (required)")
+	tagValue := flag.String("tag-value", "", "Tag value to search for (required)")
+	addrType := flag.String("addr-type", "private_v4", "Address type: private_v4, public_v4, public_v6")
+	flag.Parse()
+
+	if *region == "" || *tagKey == "" || *tagValue == "" {
+		fmt.Fprintf(os.Stderr, "Usage: %s -region <region> -tag-key <key> -tag-value <value> [-addr-type <type>]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "\nRequired flags:\n")
+		fmt.Fprintf(os.Stderr, "  -region     AWS region (e.g., us-east-1, me-central-1)\n")
+		fmt.Fprintf(os.Stderr, "  -tag-key    Tag key to search for\n")
+		fmt.Fprintf(os.Stderr, "  -tag-value  Tag value to search for\n")
+		fmt.Fprintf(os.Stderr, "\nOptional flags:\n")
+		fmt.Fprintf(os.Stderr, "  -addr-type  Address type: private_v4 (default), public_v4, public_v6\n")
+		fmt.Fprintf(os.Stderr, "\nEnvironment variables:\n")
+		fmt.Fprintf(os.Stderr, "  AWS_USE_DUALSTACK_ENDPOINT  Set to 'false' to disable dual-stack endpoints\n")
+		fmt.Fprintf(os.Stderr, "  AWS_REGION                  Default region (overridden by -region flag)\n")
+		fmt.Fprintf(os.Stderr, "  AWS_ACCESS_KEY_ID           AWS access key (optional, uses default chain)\n")
+		fmt.Fprintf(os.Stderr, "  AWS_SECRET_ACCESS_KEY       AWS secret key (optional, uses default chain)\n")
+		os.Exit(1)
+	}
+
+	// Show current configuration
+	dualStackEnv := os.Getenv("AWS_USE_DUALSTACK_ENDPOINT")
+	if dualStackEnv == "" {
+		dualStackEnv = "(not set - dual-stack enabled by default)"
+	}
+	fmt.Printf("Configuration:\n")
+	fmt.Printf("  Region:                       %s\n", *region)
+	fmt.Printf("  Tag:                          %s=%s\n", *tagKey, *tagValue)
+	fmt.Printf("  Address type:                 %s\n", *addrType)
+	fmt.Printf("  AWS_USE_DUALSTACK_ENDPOINT:   %s\n", dualStackEnv)
+	fmt.Println()
+
+	// Build discover config
+	cfg := discover.Config{
+		"provider":  "aws",
+		"region":    *region,
+		"tag_key":   *tagKey,
+		"tag_value": *tagValue,
+		"addr_type": *addrType,
+	}
+
+	// Create discoverer
+	d, err := discover.New()
+	if err != nil {
+		log.Fatalf("Failed to create discoverer: %v", err)
+	}
+
+	// Create logger that writes to stderr
+	l := log.New(os.Stderr, "", log.LstdFlags)
+
+	fmt.Printf("Discovering instances...\n\n")
+
+	// Perform discovery
+	addrs, err := d.Addrs(cfg.String(), l)
+	if err != nil {
+		log.Fatalf("Discovery failed: %v", err)
+	}
+
+	// Print results
+	if len(addrs) == 0 {
+		fmt.Printf("No instances found with tag %s=%s in region %s\n", *tagKey, *tagValue, *region)
+	} else {
+		fmt.Printf("Found %d instance(s):\n", len(addrs))
+		for i, addr := range addrs {
+			fmt.Printf("  %d. %s\n", i+1, addr)
+		}
+	}
+}


### PR DESCRIPTION
The previous implementation called aws.GetUseDualStackEndpoint() without arguments, which always returns (Unset, false) since it requires endpoint resolver options to inspect. This meant AWS_USE_DUALSTACK_ENDPOINT=false was not being honored, causing failures in regions without dual-stack endpoints (e.g., me-central-1).

The fix uses config.NewEnvConfig().GetUseDualStackEndpoint() to properly read the environment variable. When explicitly set to "false", dual-stack is now disabled. When "true" or unset, behavior is unchanged (dual-stack enabled for backward compatibility).

This is a backward-compatible fix:
- AWS_USE_DUALSTACK_ENDPOINT=true  -> dual-stack enabled (unchanged)
- AWS_USE_DUALSTACK_ENDPOINT unset -> dual-stack enabled (unchanged)
- AWS_USE_DUALSTACK_ENDPOINT=false -> dual-stack disabled (THE FIX)

Also adds:
- Table-driven tests for both static credentials and default credential chain (IAM role) paths covering all dual-stack configurations
- A test CLI tool (cmd/test-aws-discover) for manual verification in AWS, since unit tests cannot fully verify endpoint behavior without real AWS API calls

Fixes hashicorp/go-discover#293

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
