### PR TITLE
feat: introducing SRV service discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ function.
  * Openstack [Config options](https://github.com/hashicorp/go-discover/blob/8b3ddf4/provider/os/os_discover.go#L29-L44)
  * Scaleway [Config options](https://github.com/hashicorp/go-discover/blob/8b3ddf4/provider/scaleway/scaleway_discover.go#L14-L22)
  * SoftLayer [Config options](https://github.com/hashicorp/go-discover/blob/8b3ddf4/provider/softlayer/softlayer_discover.go#L16-L25)
+ * SRV [Config options](https://github.com/hashicorp/go-discover/blob/8b3ddf4/provider/srv/srv_discover.go#L14-L25)
  * TencentCloud [Config options](https://github.com/hashicorp/go-discover/blob/8b3ddf4/provider/tencentcloud/tencentcloud_discover.go#L23-L37)
  * Triton [Config options](https://github.com/hashicorp/go-discover/blob/8b3ddf4/provider/triton/triton_discover.go#L17-L27)
  * vSphere [Config options](https://github.com/hashicorp/go-discover/blob/8b3ddf4/provider/vsphere/vsphere_discover.go#L145-L157)
@@ -80,6 +81,9 @@ provider=scaleway organization=my-org tag_name=consul-server token=... region=..
 
 # SoftLayer
 provider=softlayer datacenter=dal06 tag_value=consul username=... api_key=...
+
+# SRV
+provider=srv service=consul proto=tcp domain=consul
 
 # TencentCloud
 provider=tencentcloud region=ap-guangzhou tag_key=consul tag_value=... access_key_id=... access_key_secret=...

--- a/discover.go
+++ b/discover.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/go-discover/provider/packet"
 	"github.com/hashicorp/go-discover/provider/scaleway"
 	"github.com/hashicorp/go-discover/provider/softlayer"
+	"github.com/hashicorp/go-discover/provider/srv"
 	"github.com/hashicorp/go-discover/provider/tencentcloud"
 	"github.com/hashicorp/go-discover/provider/triton"
 	"github.com/hashicorp/go-discover/provider/vsphere"
@@ -58,6 +59,7 @@ var Providers = map[string]Provider{
 	"os":           &os.Provider{},
 	"scaleway":     &scaleway.Provider{},
 	"softlayer":    &softlayer.Provider{},
+	"srv":          &srv.Provider{},
 	"tencentcloud": &tencentcloud.Provider{},
 	"triton":       &triton.Provider{},
 	"vsphere":      &vsphere.Provider{},

--- a/provider/srv/srv_discovery.go
+++ b/provider/srv/srv_discovery.go
@@ -46,7 +46,7 @@ func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error
 	if domain == "" || service == "" {
 		return nil, fmt.Errorf("discover-srv: service or domain is required")
 	}
-	log.Printf("[INFO] srv: Using service=%s proto=%s domain=%s", service, proto, domain)
+	l.Printf("[INFO] srv: Using service=%s proto=%s domain=%s", service, proto, domain)
 
 	_, records, err := net.LookupSRV(service, proto, domain)
 	if err != nil {

--- a/provider/srv/srv_discovery.go
+++ b/provider/srv/srv_discovery.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2017, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+// Package srv provides node discovery for SRV dns entries.
+package srv
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+)
+
+type Provider struct {
+	userAgent string
+}
+
+func (p *Provider) SetUserAgent(s string) {
+	p.userAgent = s
+}
+
+func (p *Provider) Help() string {
+	return `SRV:
+
+    provider:   "srv"
+    service:    The SRV service to filter on
+    proto:      The protocol to filter on
+    domain:     The SRV domain to filter on
+`
+}
+
+func (p *Provider) Addrs(args map[string]string, l *log.Logger) ([]string, error) {
+	if args["provider"] != "srv" {
+		return nil, fmt.Errorf("discover-srv: invalid provider %s", args["provider"])
+	}
+
+	if l == nil {
+		l = log.New(io.Discard, "", 0)
+	}
+	proto := args["proto"]
+	if proto == "" {
+		proto = "tcp"
+	}
+	domain := args["domain"]
+	service := args["service"]
+	if domain == "" || service == "" {
+		return nil, fmt.Errorf("discover-srv: service or domain is required")
+	}
+	log.Printf("[INFO] srv: Using service=%s proto=%s domain=%s", service, proto, domain)
+
+	_, records, err := net.LookupSRV(service, proto, domain)
+	if err != nil {
+		return nil, err
+	}
+
+	var addrs []string
+	for _, r := range records {
+		l.Printf("[INFO] discover-srv: %s:%d", r.Target, r.Port)
+		addrs = append(addrs, fmt.Sprintf("%s:%d", r.Target, r.Port))
+	}
+	return addrs, nil
+}

--- a/provider/srv/srv_discovery_test.go
+++ b/provider/srv/srv_discovery_test.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2017, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package srv_test
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	discover "github.com/hashicorp/go-discover"
+	"github.com/hashicorp/go-discover/provider/srv"
+)
+
+var _ discover.Provider = (*srv.Provider)(nil)
+var _ discover.ProviderWithUserAgent = (*srv.Provider)(nil)
+
+func TestSRVAddrs(t *testing.T) {
+	args := discover.Config{
+		"provider": "srv",
+		"service":  "ldap",
+		"domain":   "google.com",
+	}
+
+	l := log.New(os.Stderr, "", log.LstdFlags)
+	p := &srv.Provider{}
+	addrs, err := p.Addrs(args, l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("bad: %v", addrs)
+	}
+}


### PR DESCRIPTION
This PR adds service discovery based on SRV DNS entries. This will allow people to bootstrap physical datacenter setups to bootstrap from a dynamic list instead of having to hardcode the server entries. This PR is similar to the mDNS functionality but implements this functionality backed by actual DNS servers instead of local network advertisements

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
