### PR TITLE
update golangci-lint to v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ default: copywriteheaders lint test
 .PHONY: deps
 deps:
 	@go install github.com/hashicorp/copywrite@b3e6599f43beff698f471c6f46888045453fa030 # v0.25.3
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@c0d3ddc9cf3faa61a4e378e879ece580256d76e5 # v2.12.2
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
**Why?**
- make lint was not working.

**Description:**

-  **Wrong module path** — golangci-lint migrated to a v2 module structure. The correct import path is `github.com/golangci/golangci-lint/v2/cmd/golangci-lint`, not the old v1 path `github.com/golangci/golangci-lint/cmd/golangci-lint`.

- **Version tag** — `golangci-lint/v2` uses a multi-module repo layout where `cmd/golangci-lint` is a sub-directory. Go's go install cannot resolve a bare commit hash for a sub-module path — it requires a proper semver tag.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
